### PR TITLE
Adds support for different marking schemes

### DIFF
--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -129,7 +129,7 @@ import BaseIcon from "./UI/Icons/BaseIcon.vue";
 import IconButton from "./UI/Buttons/IconButton.vue";
 import domtoimage from "dom-to-image";
 import { useStore } from "vuex";
-import { ScorecardMetric, ScorecardResult } from "../types";
+import { ScorecardMetric, CircularProgressResult } from "../types";
 
 const confetti = require("canvas-confetti");
 const PROGRESS_BAR_ANIMATION_DELAY_TIME = 500; // a time delay to be used for animating the progress bar
@@ -173,14 +173,14 @@ export default defineComponent({
     /** progress to show on the progress bar (in %) */
     progressPercentage: {
       required: true,
-      type: Number,
+      type: Number || null,
     },
     title: {
       required: true,
       type: String,
     },
     result: {
-      type: Object as PropType<ScorecardResult>,
+      type: Object as PropType<CircularProgressResult>,
       default: () => {},
     },
   },
@@ -259,6 +259,7 @@ export default defineComponent({
       if (
         !props.hasGradedQuestions ||
         props.progressPercentage == null ||
+        props.result.value == null ||
         state.isMobileLandscape
       ) {
         return false;

--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -36,7 +36,7 @@
           :radius="circularProgressRadius"
           :stroke="circularProgressStroke"
           :result="result"
-          :progressBarPercent="localProgressBarPercentage"
+          :progressBarPercent="localProgressBarPercent"
           :key="reRenderKey"
           data-test="progress"
         >
@@ -192,7 +192,7 @@ export default defineComponent({
       resize: true,
     });
     const state = reactive({
-      localProgressBarPercentage: 0, // local value of progress
+      localProgressBarPercent: 0, // local value of progress
       innerWidth: window.innerWidth, // variable to hold the width of window
       reRenderKey: false, // a key to re-render a component
       // classes for watch again button
@@ -223,13 +223,13 @@ export default defineComponent({
       (newValue) => {
         if (newValue) {
           setTimeout(() => {
-            state.localProgressBarPercentage = props.progressPercentage;
+            state.localProgressBarPercent = props.progressPercentage;
           }, PROGRESS_BAR_ANIMATION_DELAY_TIME);
           // throw some confetti in there
           throwConfetti(state.confettiHandler);
         } else {
           // if scorecard is not visible anymore, reset things
-          state.localProgressBarPercentage = 0;
+          state.localProgressBarPercent = 0;
         }
       }
     );

--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -35,7 +35,8 @@
           class="relative mx-auto w-full flex justify-center"
           :radius="circularProgressRadius"
           :stroke="circularProgressStroke"
-          :result="progressBarResult"
+          :result="result"
+          :progressBarPercent="localProgressBarPercentage"
           :key="reRenderKey"
         >
         </CircularProgress>
@@ -128,7 +129,7 @@ import BaseIcon from "./UI/Icons/BaseIcon.vue";
 import IconButton from "./UI/Buttons/IconButton.vue";
 import domtoimage from "dom-to-image";
 import { useStore } from "vuex";
-import { ScorecardMetric } from "../types";
+import { ScorecardMetric, ScorecardResult } from "../types";
 
 const confetti = require("canvas-confetti");
 const PROGRESS_BAR_ANIMATION_DELAY_TIME = 500; // a time delay to be used for animating the progress bar
@@ -177,6 +178,10 @@ export default defineComponent({
     title: {
       required: true,
       type: String,
+    },
+    result: {
+      type: Object as PropType<ScorecardResult>,
+      default: () => {},
     },
   },
   setup(props, context) {
@@ -236,7 +241,7 @@ export default defineComponent({
         numQuestionsAnsweredText.value
       } questions with ${Math.round(
         state.localProgressBarPercentage
-      )}% accuracy on Avanti Fellows quiz today!`;
+      )} accuracy on Avanti Fellows quiz today!`;
     });
 
     /**
@@ -261,14 +266,6 @@ export default defineComponent({
         return false;
       }
       return true;
-    });
-    /** the result to show in the centre of the progress bar */
-    const progressBarResult = computed(() => {
-      return {
-        enabled: true,
-        title: "Accuracy",
-        value: Math.round(state.localProgressBarPercentage),
-      };
     });
     /**
      * reactively control the radius of the circular progress bar
@@ -430,7 +427,6 @@ export default defineComponent({
       shareButtonTitleConfig,
       circularProgressRadius,
       circularProgressStroke,
-      progressBarResult,
     };
   },
   emits: ["go-back"],

--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -234,14 +234,12 @@ export default defineComponent({
     );
 
     /**
-     * returns the text to be shared for % accuracy and number of questions answered
+     * returns the text to be shared for showing result and number of questions answered
      */
     const resultTextToShare = computed(() => {
-      return `I answered ${
-        numQuestionsAnsweredText.value
-      } questions with ${Math.round(
-        state.localProgressBarPercentage
-      )} accuracy on Avanti Fellows quiz today!`;
+      return `I answered ${numQuestionsAnsweredText.value} questions with ${
+        props.result.value
+      } ${props.result.title.toLowerCase()} on Avanti Fellows quiz today!`;
     });
 
     /**

--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -38,6 +38,7 @@
           :result="result"
           :progressBarPercent="localProgressBarPercentage"
           :key="reRenderKey"
+          data-test="progress"
         >
         </CircularProgress>
 

--- a/src/components/UI/Progress/CircularProgress.vue
+++ b/src/components/UI/Progress/CircularProgress.vue
@@ -45,7 +45,7 @@
 
 <script lang="ts">
 import { defineComponent, reactive, toRefs, computed, PropType } from "vue";
-import { ScorecardResult } from "../../../types";
+import { CircularProgressResult } from "../../../types";
 
 export default defineComponent({
   name: "CircularProgress",
@@ -64,7 +64,7 @@ export default defineComponent({
      * the result to be shown in the centre of the progress bar
      */
     result: {
-      type: Object as PropType<ScorecardResult>,
+      type: Object as PropType<CircularProgressResult>,
       required: true,
     },
     progressBarPercent: {

--- a/src/components/UI/Progress/CircularProgress.vue
+++ b/src/components/UI/Progress/CircularProgress.vue
@@ -30,12 +30,18 @@
       data-test="result"
     >
       <div class="w-full flex justify-center">
-        <p class="text-xl sm:text-2xl md:text-3xl font-extrabold text-center">
+        <p
+          class="text-xl sm:text-2xl md:text-3xl font-extrabold text-center"
+          data-test="value"
+        >
           {{ result.value }}
         </p>
       </div>
       <div class="w-full flex justify-center">
-        <p class="text-sm sm:text-sm md:text-base lg:text-xl text-center">
+        <p
+          class="text-sm sm:text-sm md:text-base lg:text-xl text-center"
+          data-test="title"
+        >
           {{ result.title }}
         </p>
       </div>

--- a/src/components/UI/Progress/CircularProgress.vue
+++ b/src/components/UI/Progress/CircularProgress.vue
@@ -26,15 +26,12 @@
     </svg>
     <!-- progress indicator in the center of the circle  -->
     <div
-      v-if="isResultShown"
       class="absolute inset-1/3 flex flex-col justify-center"
       data-test="result"
     >
       <div class="w-full flex justify-center">
-        <p
-          class="text-4xl sm:text-5xl md:text-[52px] lg:text-6xl font-extrabold text-center"
-        >
-          {{ progressBarPercent }}%
+        <p class="text-2xl sm:text-3xl md:text-4xl font-extrabold text-center">
+          {{ result.value }}
         </p>
       </div>
       <div class="w-full flex justify-center">
@@ -47,7 +44,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs, computed } from "vue";
+import { defineComponent, reactive, toRefs, computed, PropType } from "vue";
+import { ScorecardResult } from "../../../types";
 
 export default defineComponent({
   name: "CircularProgress",
@@ -64,10 +62,13 @@ export default defineComponent({
     },
     /**
      * the result to be shown in the centre of the progress bar
-     * - whether it is enabled and its title
      */
     result: {
-      type: Object,
+      type: Object as PropType<ScorecardResult>,
+      required: true,
+    },
+    progressBarPercent: {
+      type: Number,
       required: true,
     },
   },
@@ -77,12 +78,6 @@ export default defineComponent({
       progressBarForegroundColor: "#10B981",
     });
 
-    /**
-     * percentage of progress to be shown in the progress bar
-     */
-    const progressBarPercent = computed(() => {
-      return props.result.value;
-    });
     /**
      * Calculating a reduced radius as we don't want the ring to overflow
      * the svg viewbox if the stroke is high
@@ -103,23 +98,15 @@ export default defineComponent({
     const strokeDashoffset = computed(() => {
       return (
         circumference.value -
-        (progressBarPercent.value / 100) * circumference.value
+        (props.progressBarPercent / 100) * circumference.value
       );
-    });
-    /**
-     * Whether a result will be shown in the center of the progress bar
-     */
-    const isResultShown = computed(() => {
-      return props.result.enabled;
     });
 
     return {
       ...toRefs(state),
-      progressBarPercent,
       normalizedRadius,
       circumference,
       strokeDashoffset,
-      isResultShown,
     };
   },
 });

--- a/src/components/UI/Progress/CircularProgress.vue
+++ b/src/components/UI/Progress/CircularProgress.vue
@@ -30,7 +30,7 @@
       data-test="result"
     >
       <div class="w-full flex justify-center">
-        <p class="text-2xl sm:text-3xl md:text-4xl font-extrabold text-center">
+        <p class="text-xl sm:text-2xl md:text-3xl font-extrabold text-center">
           {{ result.value }}
         </p>
       </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export interface paletteItemState {
   value: questionState;
 }
 
-export interface ScorecardResult {
+export interface CircularProgressResult {
   title: string;
   value: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface Question {
   max_char_limit: number | null;
   graded: boolean;
   instructions: string | null;
-  markingScheme: MarkingScheme | null;
+  marking_scheme: MarkingScheme | null;
   solution: string[] | null;
   _id: string;
   metadata: QuestionMetadata | null;
@@ -108,13 +108,13 @@ export interface QuizAPIResponse {
   instructions: string;
   _id: string;
   language: language;
-  maxMarks: number;
+  max_marks: number;
   metadata: QuizMetadata;
   navigation_mode: quizNavigationMode;
-  numAttemptsAllowed: number;
-  numGradedQuestions: number;
+  num_attempts_allowed: number;
+  num_graded_questions: number;
   shuffle: boolean;
-  timeLimit: TimeLimit | null;
+  time_limit: TimeLimit | null;
   question_sets: QuestionSet[];
 }
 
@@ -150,4 +150,9 @@ export type questionState = "success" | "error" | "neutral";
 export interface paletteItemState {
   index: number; // index of the corresponding question in the list of questions
   value: questionState;
+}
+
+export interface ScorecardResult {
+  title: string;
+  value: string;
 }

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -39,6 +39,7 @@
         :class="{
           hidden: !isScorecardShown,
         }"
+        :result="scorecardResult"
         :metrics="scorecardMetrics"
         :progressPercentage="scorecardProgress"
         :isShown="isScorecardShown"
@@ -101,6 +102,8 @@ export default defineComponent({
       numCorrect: 0, // number of correctly answered questions
       numWrong: 0, // number of wrongly answered questions
       numSkipped: 0, // number of skipped questions
+      marksScored: 0,
+      maxMarks: 0, // maximum marks that can be scored
       isScorecardShown: false, // to show the scorecard or not
       hasQuizEnded: false, // whether the quiz has ended - only valid for quizType = assessment
       sessionId: "", // id of the session created for a user-quiz combination
@@ -117,6 +120,10 @@ export default defineComponent({
       );
     });
     const isQuizLoaded = computed(() => numQuestions.value > 0);
+    const scorecardResult = computed(() => ({
+      title: isQuizAssessment.value ? "Score" : "Accuracy",
+      value: scorecardResultValue.value,
+    }));
 
     watch(
       () => state.currentQuestionIndex,
@@ -148,6 +155,8 @@ export default defineComponent({
       const questionSet = quizDetails.question_sets[0];
       state.questions = questionSet.questions;
       state.metadata = quizDetails.metadata;
+      state.maxMarks =
+        quizDetails.max_marks || quizDetails.num_graded_questions;
     }
 
     async function createSession() {
@@ -228,8 +237,17 @@ export default defineComponent({
      * progress value (0-100) to be passed to the Scorecard component
      */
     const scorecardProgress = computed(() => {
-      if (!numQuestionsAnswered.value) return 0;
-      return (state.numCorrect / numQuestionsAnswered.value) * 100;
+      if (!state.maxMarks) return 0;
+      return Math.max(state.marksScored / state.maxMarks, 0) * 100;
+    });
+
+    /** result to be shown in the center of the progress bar of Scorecard */
+    const scorecardResultValue = computed(() => {
+      if (!state.maxMarks) return 0;
+      if (isQuizAssessment.value) {
+        return `${state.marksScored} / ${state.maxMarks}`;
+      }
+      return `${scorecardProgress.value}%`;
     });
 
     /**
@@ -241,8 +259,8 @@ export default defineComponent({
 
     const numNonGradedQuestions = computed(() => {
       let count = 0;
-      state.questions.forEach((itemDetail) => {
-        if (!itemDetail.graded) count += 1;
+      state.questions.forEach((questionDetail) => {
+        if (!questionDetail.graded) count += 1;
       });
       return count;
     });
@@ -262,18 +280,36 @@ export default defineComponent({
       state.numSkipped = numGradedQuestions.value;
       state.numCorrect = 0;
       state.numWrong = 0;
+      state.marksScored = 0;
 
-      state.questions.forEach((itemDetail) => {
-        updateNumCorrectWrongSkipped(itemDetail, state.responses[index].answer);
+      state.questions.forEach((questionDetail) => {
+        updateQuestionMetrics(questionDetail, state.responses[index].answer);
         index += 1;
       });
     }
 
-    function updateNumCorrectWrongSkipped(
-      itemDetail: Question,
+    function updateQuestionMetrics(
+      questionDetail: Question,
       userAnswer: submittedAnswer
     ) {
-      const answerEvaluation = isQuestionAnswerCorrect(itemDetail, userAnswer);
+      const markingScheme = questionDetail.marking_scheme;
+
+      function updateMetricsForCorrectAnswer() {
+        state.numCorrect += 1;
+        // default marks for correctly answered questions = 1
+        state.marksScored += markingScheme?.correct || 1;
+      }
+
+      function updateMetricsForWrongAnswer() {
+        state.numWrong += 1;
+        // default marks for wrongly answered questions = 0
+        state.marksScored += markingScheme?.wrong || 0;
+      }
+
+      const answerEvaluation = isQuestionAnswerCorrect(
+        questionDetail,
+        userAnswer
+      );
       if (!answerEvaluation.valid) {
         return;
       }
@@ -282,9 +318,12 @@ export default defineComponent({
 
         if (answerEvaluation.isCorrect != null) {
           answerEvaluation.isCorrect
-            ? (state.numCorrect += 1)
-            : (state.numWrong += 1);
+            ? updateMetricsForCorrectAnswer()
+            : updateMetricsForWrongAnswer();
         }
+      } else {
+        // default marks for skipped questions = 0
+        state.marksScored += markingScheme?.skipped || 0;
       }
     }
 
@@ -306,6 +345,7 @@ export default defineComponent({
       numQuestionsAnswered,
       hasGradedQuestions,
       isQuizLoaded,
+      scorecardResult,
       startQuiz,
       submitQuestion,
       goToPreviousQuestion,

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -237,13 +237,13 @@ export default defineComponent({
      * progress value (0-100) to be passed to the Scorecard component
      */
     const scorecardProgress = computed(() => {
-      if (!state.maxMarks) return 0;
+      if (!state.maxMarks) return null;
       return Math.max(state.marksScored / state.maxMarks, 0) * 100;
     });
 
     /** result to be shown in the center of the progress bar of Scorecard */
     const scorecardResultValue = computed(() => {
-      if (!state.maxMarks) return 0;
+      if (!state.maxMarks || scorecardProgress.value == null) return null;
       if (isQuizAssessment.value) {
         return `${state.marksScored} / ${state.maxMarks}`;
       }

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -247,7 +247,7 @@ export default defineComponent({
       if (isQuizAssessment.value) {
         return `${state.marksScored} / ${state.maxMarks}`;
       }
-      return `${scorecardProgress.value}%`;
+      return `${Math.round(scorecardProgress.value)}%`;
     });
 
     /**

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -245,7 +245,7 @@ export default defineComponent({
     const scorecardResultValue = computed(() => {
       if (!state.maxMarks || scorecardProgress.value == null) return null;
       if (isQuizAssessment.value) {
-        return `${state.marksScored} / ${state.maxMarks}`;
+        return `${state.marksScored}/${state.maxMarks}`;
       }
       return `${Math.round(scorecardProgress.value)}%`;
     });

--- a/tests/e2e/fixtures/assessment_quiz.json
+++ b/tests/e2e/fixtures/assessment_quiz.json
@@ -18,7 +18,11 @@
           "max_char_limit": null,
           "correct_answer": [0],
           "graded": true,
-          "marking_scheme": null,
+          "marking_scheme": {
+            "correct": 4,
+            "wrong": -2,
+            "skipped": -1
+          },
           "solution": [],
           "metadata": null
         },
@@ -45,7 +49,11 @@
           "max_char_limit": null,
           "correct_answer": [0, 2],
           "graded": true,
-          "marking_scheme": null,
+          "marking_scheme": {
+            "correct": 3,
+            "wrong": -1,
+            "skipped": -1
+          },
           "solution": [],
           "metadata": null
         },
@@ -63,7 +71,11 @@
           "max_char_limit": null,
           "correct_answer": [1],
           "graded": true,
-          "marking_scheme": null,
+          "marking_scheme": {
+            "correct": 3,
+            "wrong": -1,
+            "skipped": 0
+          },
           "solution": [],
           "metadata": null
         }
@@ -75,7 +87,7 @@
   "shuffle": false,
   "num_attempts_allowed": 1,
   "time_limit": null,
-  "navigation_mode": "linear",
+  "navigation_mode": "non-linear",
   "instructions": null,
   "language": "en",
   "metadata": {

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -162,13 +162,25 @@ describe("Player for Assessment quizzes", () => {
           .should("have.text", 1);
       });
 
-      it("shows scorecard upon selecting End Test", () => {
-        cy.get('[data-test="modal"]')
-          .get('[data-test="endTestButton"]')
-          .trigger("click");
+      describe("End test", () => {
+        beforeEach(() => {
+          cy.get('[data-test="modal"]')
+            .get('[data-test="endTestButton"]')
+            .trigger("click");
+        });
 
-        cy.get('[data-test="modal"]').should("not.exist");
-        cy.get('[data-test="scorecard"]').should("exist");
+        it("shows scorecard upon selecting End Test", () => {
+          cy.get('[data-test="modal"]').should("not.exist");
+          cy.get('[data-test="scorecard"]').should("exist");
+        });
+
+        it("shows score instead of accuracy in scorecard", () => {
+          const progressBar = cy
+            .get('[data-test="scorecard"]')
+            .get('[data-test="progress"]');
+          progressBar.get('[data-test="value"]').should("contain", "/");
+          progressBar.get('[data-test="title"]').should("contain", "Score");
+        });
       });
 
       describe("Question Palette", () => {

--- a/tests/e2e/specs/renders-player-homework.js
+++ b/tests/e2e/specs/renders-player-homework.js
@@ -47,48 +47,60 @@ describe("Player for homework quizzes", () => {
         cy.get('[data-test="modal"]').should("exist");
       });
 
-      it("scorecard shown when all questions are answered", () => {
-        cy.get('[data-test="startQuiz"]').trigger("click");
+      describe("all questions answered", () => {
+        beforeEach(() => {
+          cy.get('[data-test="startQuiz"]').trigger("click");
 
-        // question 1
-        cy.get('[data-test="modal"]')
-          .get('[data-test="optionSelector-0"]')
-          .trigger("click");
-        cy.get('[data-test="modal"]')
-          .get('[data-test="submitButton"]')
-          .trigger("click");
-        // continue button
-        cy.get('[data-test="modal"]')
-          .get('[data-test="submitButton"]')
-          .trigger("click");
+          // question 1
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .trigger("click");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="submitButton"]')
+            .trigger("click");
+          // continue button
+          cy.get('[data-test="modal"]')
+            .get('[data-test="submitButton"]')
+            .trigger("click");
 
-        // question 2
-        cy.get('[data-test="modal"]')
-          .get('[data-test="optionSelector-0"]')
-          .trigger("click");
-        cy.get('[data-test="modal"]')
-          .get('[data-test="submitButton"]')
-          .trigger("click");
-        // continue button
-        cy.get('[data-test="modal"]')
-          .get('[data-test="submitButton"]')
-          .trigger("click");
+          // question 2
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .trigger("click");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="submitButton"]')
+            .trigger("click");
+          // continue button
+          cy.get('[data-test="modal"]')
+            .get('[data-test="submitButton"]')
+            .trigger("click");
 
-        // question 3
-        cy.get('[data-test="modal"]')
-          .get('[data-test="optionSelector-0"]')
-          .trigger("click");
-        cy.get('[data-test="modal"]')
-          .get('[data-test="submitButton"]')
-          .trigger("click");
-        // continue button
-        cy.get('[data-test="modal"]')
-          .get('[data-test="submitButton"]')
-          .trigger("click");
+          // question 3
+          cy.get('[data-test="modal"]')
+            .get('[data-test="optionSelector-0"]')
+            .trigger("click");
+          cy.get('[data-test="modal"]')
+            .get('[data-test="submitButton"]')
+            .trigger("click");
+          // continue button
+          cy.get('[data-test="modal"]')
+            .get('[data-test="submitButton"]')
+            .trigger("click");
+        });
 
-        cy.get('[data-test="splash"]').should("not.exist");
-        cy.get('[data-test="modal"]').should("not.exist");
-        cy.get('[data-test="scorecard"]').should("exist");
+        it("scorecard shown", () => {
+          cy.get('[data-test="splash"]').should("not.exist");
+          cy.get('[data-test="modal"]').should("not.exist");
+          cy.get('[data-test="scorecard"]').should("exist");
+        });
+
+        it("scorecard shows % accuracy", () => {
+          const progressBar = cy
+            .get('[data-test="scorecard"]')
+            .get('[data-test="progress"]');
+          progressBar.get('[data-test="value"]').should("contain", "%");
+          progressBar.get('[data-test="title"]').should("contain", "Accuracy");
+        });
       });
     });
 

--- a/tests/unit/components/Scorecard.spec.ts
+++ b/tests/unit/components/Scorecard.spec.ts
@@ -103,7 +103,7 @@ describe("Scorecard.vue", () => {
 
     jest.advanceTimersByTime(1000);
 
-    expect(wrapper.vm.localProgressBarPercentage).toBe(progressPercentage);
+    expect(wrapper.vm.localProgressBarPercent).toBe(progressPercentage);
 
     await wrapper.setProps({
       isShown: false,
@@ -111,7 +111,7 @@ describe("Scorecard.vue", () => {
     await flushPromises();
     await jest.advanceTimersByTime(1000);
 
-    expect(wrapper.vm.localProgressBarPercentage).toBe(0);
+    expect(wrapper.vm.localProgressBarPercent).toBe(0);
   });
 
   it("share text on whatsapp when no questions answered", async () => {

--- a/tests/unit/components/Scorecard.spec.ts
+++ b/tests/unit/components/Scorecard.spec.ts
@@ -202,4 +202,13 @@ describe("Scorecard.vue", () => {
     await wrapper.find('[data-test="share"]').trigger("click");
     expect(globalThis.navigator.share).not.toHaveBeenCalled();
   });
+
+  it("does not show circular progress bar is result value is null", async () => {
+    await wrapper.setProps({
+      result: {
+        value: null,
+      },
+    });
+    expect(wrapper.vm.isCircularProgressShown).toBeFalsy();
+  });
 });

--- a/tests/unit/components/Scorecard.spec.ts
+++ b/tests/unit/components/Scorecard.spec.ts
@@ -47,6 +47,10 @@ describe("Scorecard.vue", () => {
           },
         },
       ],
+      result: {
+        title: "Accuracy",
+        value: "100%",
+      },
     },
     global: {
       provide: {
@@ -114,7 +118,7 @@ describe("Scorecard.vue", () => {
     await wrapper.find('[data-test="share"]').trigger("click");
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      "https://api.whatsapp.com/send/?phone&text=%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%0A%0A%F0%9F%8F%86%20*Hooray!%20I%20completed%20a%20Quiz!*%20%F0%9F%8F%86%0A%0A%F0%9F%8C%9F%20*dummyTitle*%20%F0%9F%8C%9F%0A%0AI%20answered%202%20questions%20with%200%25%20accuracy%20on%20Avanti%20Fellows%20quiz%20today!%20%F0%9F%98%87%0A%0A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A"
+      "https://api.whatsapp.com/send/?phone&text=%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%0A%0A%F0%9F%8F%86%20*Hooray!%20I%20completed%20a%20Quiz!*%20%F0%9F%8F%86%0A%0A%F0%9F%8C%9F%20*dummyTitle*%20%F0%9F%8C%9F%0A%0AI%20answered%202%20questions%20with%20100%25%20accuracy%20on%20Avanti%20Fellows%20quiz%20today!%20%F0%9F%98%87%0A%0A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A"
     );
   });
 
@@ -132,7 +136,7 @@ describe("Scorecard.vue", () => {
     await wrapper.find('[data-test="share"]').trigger("click");
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      `https://api.whatsapp.com/send/?phone&text=%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%0A%0A%F0%9F%8F%86%20*Hooray!%20I%20completed%20a%20Quiz!*%20%F0%9F%8F%86%0A%0A%F0%9F%8C%9F%20*Geometry%20Quiz*%20%F0%9F%8C%9F%0A%0AI%20answered%204%20questions%20with%2050%25%20accuracy%20on%20Avanti%20Fellows%20quiz%20today!%20%F0%9F%98%87%0A%0A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A`
+      `https://api.whatsapp.com/send/?phone&text=%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%0A%0A%F0%9F%8F%86%20*Hooray!%20I%20completed%20a%20Quiz!*%20%F0%9F%8F%86%0A%0A%F0%9F%8C%9F%20*Geometry%20Quiz*%20%F0%9F%8C%9F%0A%0AI%20answered%204%20questions%20with%20100%25%20accuracy%20on%20Avanti%20Fellows%20quiz%20today!%20%F0%9F%98%87%0A%0A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A`
     );
   });
 
@@ -150,7 +154,7 @@ describe("Scorecard.vue", () => {
     await wrapper.find('[data-test="share"]').trigger("click");
 
     expect(mockWindowOpen).toHaveBeenCalledWith(
-      `https://api.whatsapp.com/send/?phone&text=%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%0A%0A%F0%9F%8F%86%20*Hooray!%20I%20completed%20a%20Quiz!*%20%F0%9F%8F%86%0A%0A%F0%9F%8C%9F%20*Geometry%20Quiz*%20%F0%9F%8C%9F%0A%0AI%20answered%204%20questions%20with%2050%25%20accuracy%20on%20Avanti%20Fellows%20quiz%20today!%20%F0%9F%98%87%0A%0A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A`
+      `https://api.whatsapp.com/send/?phone&text=%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%0A%0A%F0%9F%8F%86%20*Hooray!%20I%20completed%20a%20Quiz!*%20%F0%9F%8F%86%0A%0A%F0%9F%8C%9F%20*Geometry%20Quiz*%20%F0%9F%8C%9F%0A%0AI%20answered%204%20questions%20with%20100%25%20accuracy%20on%20Avanti%20Fellows%20quiz%20today!%20%F0%9F%98%87%0A%0A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A%F0%9F%8E%89%F0%9F%8E%8A`
     );
   });
   it("triggers domtoimage when share button is clicked where supported", async () => {

--- a/tests/unit/components/UI/Progress/CircularProgress.spec.ts
+++ b/tests/unit/components/UI/Progress/CircularProgress.spec.ts
@@ -11,10 +11,10 @@ describe("CircularProgress.vue", () => {
         radius: radius,
         stroke: stroke,
         result: {
-          enabled: true,
           title: "temp text",
-          value: progress,
+          value: `${progress}%`,
         },
+        progressBarPercent: progress,
       },
     });
 
@@ -26,7 +26,6 @@ describe("CircularProgress.vue", () => {
     expect(wrapper.vm.normalizedRadius).toBe(expectedNormalizedRadius);
     expect(wrapper.vm.circumference).toBe(expectedCircumference);
     expect(wrapper.vm.strokeDashoffset).toBe(expectedStrokeDashoffset);
-    expect(wrapper.vm.isResultShown).toBeTruthy();
 
     expect(wrapper.find('[data-test="result"]').exists()).toBeTruthy();
   });


### PR DESCRIPTION
Fixes #49 

Dev DB Quiz Id for testing - `626ba011b1de73f38b8def60`

## Summary
- earlier, it was assumed in the `CircularProgress` component that the % to be shown as progress and the value in the middle would be the same. Have decoupled the two.
- Passing % accuracy for `quizType = homework` and `marksScored / maxMarks` for `quizType = assessment`.
- Computes marksScored based on the marking scheme defined for each question
- Fixed the CSS of the `CircularProgress` component to account for the range of values we are likely to see.

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [ ] Laptop (1200px)
  - [ ] Tablet (760px)
  - [ ] Phone (320px)
- [x] Cross-Browser Testing
  - [ ] Chrome
  - [ ] Firefox
- [ ] ~Local Language Support~
- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
  - [x] Added relevant details like Labels/Projects/Milestones etc.
  - [ ] ~If adding or removing any environment variable, update `docs/ENV.md`, `.env.example` and the Github workflows.~
- [ ] Testing
  - [x] Wrote tests
  - [x] Tested locally
  - [x] Tested on staging
  - [ ] Tested on an actual physical phone
  - [ ] Tested on production
- [ ] Lighthouse Checks
  - [ ] ~Images have `alt` attributes~
  - [ ] ~Any `<img>` tags have `width` and `height` specified~
  - [ ] ~Any `target="_blank"` links have `rel="noopener"`~
  - [ ] ~Only SVGs are used as images. If PNGs are used, their size has been optimised.~
  - [ ] ~Any SVG buttons without text have their `aria-label` attributes set~
