### PR TITLE
Prevent extra scrolling area in mobile screens

### DIFF
--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-screen">
+  <div class="h-full">
     <!-- loading spinner -->
     <div v-if="!isQuizLoaded" class="flex justify-center h-full">
       <BaseIcon


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/question-set-player) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/question-set-player#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/style-guide/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

## Summary

Replaced `h-screen` with `h-full` in the outermost wrapper. `h-screen` was the reason someone was able to scroll extra on a mobile screen.