### PR TITLE
Adds additional step to end test

### DIFF
--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -135,6 +135,7 @@ export default defineComponent({
       isDraftAnswerCleared: false, // whether the draft answer has been cleared but not yet submitted
       isPaletteVisible: false, // whether the question palette is visible
       reRenderKey: false, // a key to re-render a component
+      hasEndTestBeenClickedOnce: true
     })
 
     // display warning when time remaining goes below this threshold (in minutes)
@@ -275,8 +276,26 @@ export default defineComponent({
     }
 
     function endTest() {
-      state.localCurrentQuestionIndex = props.questions.length
-      context.emit("end-test")
+      if (!props.hasQuizEnded && state.hasEndTestBeenClickedOnce) {
+        let attemptedQuestions = 0;
+        for (const response of props.responses) {
+          if (response.answer != null) {
+            attemptedQuestions += 1;
+          }
+        }
+        state.toast.success(
+            `You have answered ${attemptedQuestions} out of ${props.questions.length} questions. Please verify your responses and click End Test button again to make final submission.`,
+            {
+              position: POSITION.TOP_CENTER,
+              timeout: 5000,
+              draggablePercent: 0.4
+            }
+        )
+        state.hasEndTestBeenClickedOnce = false;
+      } else {
+        state.localCurrentQuestionIndex = props.questions.length
+        context.emit("end-test")
+      }
     }
 
     function endTestByTime() {

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -172,6 +172,11 @@ describe("Player for Assessment quizzes", () => {
           .get('[data-test="endTestButton"]')
           .trigger("click");
 
+        // additional click to protect endTest button
+        cy.get('[data-test="modal"]')
+          .get('[data-test="endTestButton"]')
+          .trigger("click");
+
         // number of skipped questions shown in scorecard
         cy.get('[data-test="scorecard"]')
           .get('[data-test="metricValue-2"]')
@@ -183,6 +188,10 @@ describe("Player for Assessment quizzes", () => {
           cy.get('[data-test="modal"]')
             .get('[data-test="endTestButton"]')
             .trigger("click");
+
+          cy.get('[data-test="modal"]')
+            .get('[data-test="endTestButton"]')
+            .trigger("click"); // additional click to protect endTest button
         });
 
         it("shows scorecard upon selecting End Test", () => {

--- a/tests/e2e/specs/renders-player-to-check-timed.js
+++ b/tests/e2e/specs/renders-player-to-check-timed.js
@@ -118,6 +118,11 @@ describe("Player for Assessment Timed quizzes", () => {
           .get('[data-test="endTestButton"]')
           .trigger("click");
 
+        // click again since endTest button protected by additional click
+        cy.get('[data-test="modal"]')
+          .get('[data-test="endTestButton"]')
+          .trigger("click");
+
         // wait for END_QUIZ patch to be called
         cy.wait("@patch_session");
         // check if payload has END_QUIZ event

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -271,6 +271,7 @@ describe("QuestionModal.vue", () => {
       });
       it("sets question index to number of questions upon end test", async () => {
         wrapper.find('[data-test="endTestButton"]').trigger("click");
+        wrapper.find('[data-test="endTestButton"]').trigger("click"); // adding additional click to protect endTest button
         expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length);
       });
       it("does not increment question index when save & next button is clicked for last question", () => {


### PR DESCRIPTION
1. Small PR to add extra step before ending test. 

The way it works --> 
a. If end test button has been clicked the first time, we display a toast saying - "You have answered xx out of yy questions. Please check once again before submitting"
b. If the button is clicked again, the test ends. 

Idea is to revert this change back and write better code later on -- wherein we show an alert box of sorts. 