### PR TITLE
Enable Subset pattern logic for Previous button click

### DIFF
--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -251,6 +251,9 @@ export default defineComponent({
     function showPreviousQuestion() {
       state.reRenderKey = !state.reRenderKey
       resetState()
+      if (!isQuestionFetched(state.localCurrentQuestionIndex - 1)) {
+        context.emit("fetch-question-bucket", state.localCurrentQuestionIndex - 1)
+      }
       state.localCurrentQuestionIndex -= 1
     }
 


### PR DESCRIPTION
Small bug. Solves #95 

- Fetches bucket if not already fetched when previous button is clicked.