### PR TITLE
Wait until session answer request returns

### DIFF
--- a/src/components/Omr/OmrModal.vue
+++ b/src/components/Omr/OmrModal.vue
@@ -8,6 +8,7 @@
         :title="title"
         :userId="userId"
         :isOmrMode="isOmrMode"
+        :isSessionAnswerRequestProcessing="isSessionAnswerRequestProcessing"
         v-model:isPaletteVisible="isPaletteVisible"
         :timeRemaining="timeRemaining"
         :warningTimeLimit="timeLimitWarningThreshold"
@@ -113,6 +114,10 @@ export default defineComponent({
     responses: {
       required: true,
       type: Array as PropType<SubmittedResponse[]>
+    },
+    isSessionAnswerRequestProcessing: {
+      type: Boolean,
+      default: false
     },
     quizType: {
       type: String as PropType<quizType>,
@@ -276,7 +281,6 @@ export default defineComponent({
         )
         state.hasEndTestBeenClickedOnce = false;
       } else {
-        state.localCurrentQuestionIndex = props.questions.length
         context.emit("end-test")
       }
     }
@@ -284,7 +288,6 @@ export default defineComponent({
     function endTestByTime() {
       // same function as above -- can update later for new feature
       if (!props.hasQuizEnded && isQuizAssessment.value) {
-        state.localCurrentQuestionIndex = props.questions.length
         context.emit("end-test")
       }
     }

--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -15,6 +15,7 @@
           hidden: !isPreviousButtonShown && !isQuizAssessment,
           invisible: (!isPreviousButtonShown && isQuizAssessment) || isOmrMode,
         }"
+        :isDisabled="isSessionAnswerRequestProcessing"
         ariaLabel="Previous Question"
         @click="goToPreviousQuestion"
         data-test="previousQuestionButton"
@@ -32,7 +33,7 @@
         }"
         :titleConfig="clearButtonTitleConfig"
         :buttonClass="clearButtonClass"
-        :isDisabled="!isSubmitEnabled"
+        :isDisabled="!isSubmitEnabled || isSessionAnswerRequestProcessing"
         @click="clearAnswer"
         data-test="clearButton"
       ></icon-button>
@@ -43,8 +44,9 @@
           hidden: isOmrMode
         }"
         :titleConfig="saveAndNextButtonTitleConfig"
+        :iconConfig="saveAndNextButtonIconConfig"
         :buttonClass="saveAndNextButtonClass"
-        :isDisabled="!isAnswerSubmitted && !isSubmitEnabled"
+        :isDisabled="(!isAnswerSubmitted && !isSubmitEnabled) || isSessionAnswerRequestProcessing"
         @click="saveQuestionAndProceed"
         data-test="saveAndNextButton"
       ></icon-button>
@@ -55,8 +57,9 @@
       <icon-button
         v-if="!isQuizAssessment"
         :titleConfig="submitButtonTitleConfig"
+        :iconConfig="submitButtonIconConfig"
         :buttonClass="submitButtonClass"
-        :isDisabled="!isAnswerSubmitted && !isSubmitEnabled"
+        :isDisabled="(!isAnswerSubmitted && !isSubmitEnabled) || isSessionAnswerRequestProcessing"
         @click="submitQuestion"
         data-test="submitButton"
       ></icon-button>
@@ -68,6 +71,7 @@
         v-if="isQuizAssessment && isNextButtonShown"
         :iconConfig="nextQuestionButtonIconConfig"
         :buttonClass="assessmentNavigationButtonClass"
+        :isDisabled="isSessionAnswerRequestProcessing"
         ariaLabel="Next Question"
         @click="goToNextQuestion"
         data-test="nextQuestionButton"
@@ -110,6 +114,14 @@ export default defineComponent({
     isNextButtonShown: {
       default: true,
       type: Boolean,
+    },
+    isSessionAnswerRequestProcessing: {
+      type: Boolean,
+      default: false
+    },
+    continueAfterAnswerSubmit: {
+      type: Boolean,
+      default: false
     },
     hasQuizEnded: {
       type: Boolean,
@@ -185,7 +197,16 @@ export default defineComponent({
       class: [state.assessmentTextButtonTitleClass, "text-emerald-500"],
     } as IconButtonTitleConfig);
 
+    const saveAndNextButtonIconConfig = computed(() => {
+      return {
+        enabled: props.isSessionAnswerRequestProcessing,
+        iconName: "spinner-solid",
+        iconClass: "animate-spin h-4 w-4 text-primary",
+      };
+    });
+
     function submitQuestion() {
+      // for homework ONLY
       if (props.isAnswerSubmitted) context.emit("continue");
       else context.emit("submit");
     }
@@ -203,16 +224,31 @@ export default defineComponent({
     }
 
     function saveQuestionAndProceed() {
+      // for assessment
       context.emit("submit");
-      context.emit("continue");
+      // wait for processing to be done and answer to be submitted
+      const checkProcessingDone = setInterval(() => {
+        if (!props.isSessionAnswerRequestProcessing) {
+          if (props.continueAfterAnswerSubmit) context.emit("continue");
+          clearInterval(checkProcessingDone);
+        }
+      }, 100); // check every 100ms
     }
 
     const submitButtonTitleConfig = computed(() => {
       return {
-        value: props.isAnswerSubmitted ? "Continue" : "Submit",
+        value: props.isAnswerSubmitted && !props.isSessionAnswerRequestProcessing ? "Continue" : "Submit",
         class:
           "text-white text-md bp-500:text-lg lg:text-xl xl:text-2xl font-bold",
       } as IconButtonTitleConfig;
+    });
+
+    const submitButtonIconConfig = computed(() => {
+      return {
+        enabled: props.isSessionAnswerRequestProcessing,
+        iconName: "spinner-solid",
+        iconClass: "animate-spin h-4 w-4 text-primary",
+      };
     });
 
     const submitButtonClass = computed(() => [
@@ -233,12 +269,14 @@ export default defineComponent({
       saveAndNextButtonClass,
       clearButtonTitleConfig,
       saveAndNextButtonTitleConfig,
+      saveAndNextButtonIconConfig,
       submitQuestion,
       goToPreviousQuestion,
       goToNextQuestion,
       clearAnswer,
       saveQuestionAndProceed,
       submitButtonTitleConfig,
+      submitButtonIconConfig,
       submitButtonClass,
       isQuizAssessment,
     };

--- a/src/components/Questions/Header.vue
+++ b/src/components/Questions/Header.vue
@@ -7,6 +7,7 @@
           :class="{invisible: isOmrMode}"
           :iconConfig="togglePaletteButtonIconConfig"
           :buttonClass="togglePaletteButtonClass"
+          :isDisabled="isSessionAnswerRequestProcessing"
           @click="togglePalette"
           data-test="togglePaletteButton"
         ></icon-button>
@@ -23,6 +24,8 @@
           <icon-button
             :titleConfig="endTestButtonTitleConfig"
             :buttonClass="endTestButtonClass"
+            :iconConfig="endTestButtonIconConfig"
+            :isDisabled="isSessionAnswerRequestProcessing"
             @click="endTest"
             data-test="endTestButton"
           ></icon-button>
@@ -68,6 +71,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    isSessionAnswerRequestProcessing: {
+      type: Boolean,
+      default: false
+    },
     /** whether the quiz has a time limit */
     hasTimeLimit: {
       type: Boolean,
@@ -101,11 +108,11 @@ export default defineComponent({
     });
 
     onMounted(() => {
-      if (!props.hasQuizEnded && props.hasTimeLimit) {
-        window.setInterval(() => {
+      window.setInterval(() => {
+        if (!props.hasQuizEnded && props.hasTimeLimit && !props.isSessionAnswerRequestProcessing) {
           state.timeRemaining -= 1
-        }, 1000); // update every second if quiz has not ended
-      }
+        }
+      }, 1000); // update every second if quiz has not ended
     })
 
     function endTest() {
@@ -120,6 +127,14 @@ export default defineComponent({
       class:
         "text-white text-sm bp-500:text-md lg:text-lg xl:text-xl font-bold",
     }));
+
+    const endTestButtonIconConfig = computed(() => {
+      return {
+        enabled: props.isSessionAnswerRequestProcessing && props.isOmrMode,
+        iconName: "spinner-solid",
+        iconClass: "animate-spin h-4 w-4 text-primary",
+      };
+    });
 
     const countdownTimerClass = computed(() => {
       let buttonClass;
@@ -207,6 +222,7 @@ export default defineComponent({
       endTest,
       togglePalette,
       endTestButtonTitleConfig,
+      endTestButtonIconConfig,
       togglePaletteButtonIconConfig,
       togglePaletteButtonClass,
       countdownTimerClass,

--- a/src/services/API/RootClient.ts
+++ b/src/services/API/RootClient.ts
@@ -5,6 +5,9 @@ import ErrorHandling from "./ErrorHandling";
 const client = axios.create({
   baseURL: process.env.VUE_APP_BACKEND,
   withCredentials: false,
+  timeout: 4000, // cancel request after 10 sec
+  // but this works only when internet connection is active
+  // ref: https://stackoverflow.com/questions/36690451/timeout-feature-in-the-axios-library-is-not-working
 });
 
 // handle errors in responses for API requests

--- a/src/services/API/RootClient.ts
+++ b/src/services/API/RootClient.ts
@@ -10,6 +10,17 @@ const client = axios.create({
   // ref: https://stackoverflow.com/questions/36690451/timeout-feature-in-the-axios-library-is-not-working
 });
 
+// delay response by one second to notice loading spinner
+client.interceptors.response.use(function (response) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(response);
+    }, 1000);
+  });
+}, function (error) {
+  return Promise.reject(error);
+});
+
 // handle errors in responses for API requests
 client.interceptors.response.use(
   (config: AxiosRequestConfig): AxiosRequestConfig => {

--- a/src/services/API/RootClient.ts
+++ b/src/services/API/RootClient.ts
@@ -5,20 +5,9 @@ import ErrorHandling from "./ErrorHandling";
 const client = axios.create({
   baseURL: process.env.VUE_APP_BACKEND,
   withCredentials: false,
-  timeout: 4000, // cancel request after 10 sec
+  timeout: 4000, // cancel request after 4 sec
   // but this works only when internet connection is active
   // ref: https://stackoverflow.com/questions/36690451/timeout-feature-in-the-axios-library-is-not-working
-});
-
-// delay response by one second to notice loading spinner
-client.interceptors.response.use(function (response) {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(response);
-    }, 1000);
-  });
-}, function (error) {
-  return Promise.reject(error);
 });
 
 // handle errors in responses for API requests

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -70,7 +70,6 @@ export default {
         return { status: 400 }; // bad request
       }
     }
-    return { status: 200 }; // return statement for type checking
   },
 
   /**
@@ -96,6 +95,5 @@ export default {
         return { status: 400 }; // bad request
       }
     }
-    return { status: 200 }; // return statement for type checking
   },
 };

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -6,7 +6,9 @@ import {
   UpdateSessionAPIPayload,
   UpdateSessionAPIResponse,
   UpdateSessionAnswerAPIPayload,
+  UpdateAllSessionAnswersAPIPayload
 } from "../../types";
+import axios, { AxiosError } from "axios";
 
 export default {
   /**
@@ -48,17 +50,52 @@ export default {
    *                                 This index corresponds to the index of sessionAnswer in session
    * @param {UpdateSessionAnswerAPIPayload} payload - contains the answer {submittedAnswer} that
    * needs to be updated and a boolean variable to indicate that the question is visited
-   * @returns {Promise<SessionAnswerAPIResponse>} - the updated sessionAnswer instance
+   * @returns {Promise<SessionAnswerAPIResponse>} - response status of request
    */
   async updateSessionAnswer(
     sessionId: string,
     positionIndex: number,
     payload: UpdateSessionAnswerAPIPayload
   ): Promise<SessionAnswerAPIResponse> {
-    const response = await apiClient().patch(
-      sessionAnswersEndpoint + sessionId + "/" + positionIndex,
-      payload
-    );
-    return response.data;
+    try {
+      const response = await apiClient().patch(
+        sessionAnswersEndpoint + sessionId + "/" + positionIndex,
+        payload
+      );
+      return { status: response.status };
+    } catch (error: any) {
+      if (axios.isCancel(error)) {
+        return { status: 400 }; // request cancelled
+      } else if (error.code == 'ECONNABORTED') {
+        return { status: 500 }; // request timeout
+      }
+    }
+    return { status: 200 }; // return statement for type checking
+  },
+
+  /**
+   * @param {string} sessionId - id of the session for which the sessionAnswer is to be updated
+   * @param {UpdateAllSessionAnswersAPIPayload} payload - contains list of response objects, each object
+   * includes an answer and whether the corresponding question was visited
+   * @returns {Promise<SessionAnswerAPIResponse>} - response status of request
+   */
+  async updateAllSessionAnswers(
+    sessionId: string,
+    payload: UpdateAllSessionAnswersAPIPayload
+  ): Promise<SessionAnswerAPIResponse> {
+    try {
+      const response = await apiClient().patch(
+        sessionAnswersEndpoint + sessionId,
+        payload
+      );
+      return { status: response.status };
+    } catch (error: any) {
+      if (axios.isCancel(error)) {
+        return { status: 400 }; // request cancelled
+      } else if (error.code == 'ECONNABORTED') {
+        return { status: 500 }; // request timeout
+      }
+    }
+    return { status: 200 }; // return statement for type checking
   },
 };

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -64,10 +64,10 @@ export default {
       );
       return { status: response.status };
     } catch (error: any) {
-      if (axios.isCancel(error)) {
-        return { status: 400 }; // request cancelled
-      } else if (error.code == 'ECONNABORTED') {
+      if (error.code == 'ECONNABORTED') {
         return { status: 500 }; // request timeout
+      } else {
+        return { status: 400 }; // bad request
       }
     }
     return { status: 200 }; // return statement for type checking
@@ -90,10 +90,10 @@ export default {
       );
       return { status: response.status };
     } catch (error: any) {
-      if (axios.isCancel(error)) {
-        return { status: 400 }; // request cancelled
-      } else if (error.code == 'ECONNABORTED') {
+      if (error.code == 'ECONNABORTED') {
         return { status: 500 }; // request timeout
+      } else {
+        return { status: 400 }; // bad request
       }
     }
     return { status: 200 }; // return statement for type checking

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,17 +195,15 @@ export interface UpdateSessionAPIResponse {
 }
 
 export interface SessionAnswerAPIResponse {
-  _id: string;
-  session_id: string;
-  question_id: string;
-  answer: submittedAnswer;
-  visited: boolean;
+  status: number;
 }
 
 export interface UpdateSessionAnswerAPIPayload {
   answer?: submittedAnswer;
   visited?: boolean;
 }
+
+export interface UpdateAllSessionAnswersAPIPayload extends Array<UpdateSessionAnswerAPIPayload> {}
 
 export interface answerEvaluation {
   valid: boolean; // whether the evaluation of the question is valid in the first place (invalid for ungraded questions)

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -401,7 +401,7 @@ export default defineComponent({
 
           if (updateResponse.status != 200) {
             state.toast.error(
-              'Answers are not submitted. Please check internet connection and click "End Test" again without refreshing the page',
+              'Answers are not submitted. Please check internet connection and click "End Test" again without refreshing the page.',
               {
                 position: POSITION.TOP_LEFT,
                 timeout: 8000,

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -356,10 +356,10 @@ export default defineComponent({
       );
       if (response.status != 200) {
         state.toast.error(
-          'Answer not saved. Please try to submit again or refresh the page.',
+          `Answer for Q.${state.currentQuestionIndex + 1} not saved. Please try to submit again or refresh the page.`,
           {
             position: POSITION.TOP_LEFT,
-            timeout: 5000,
+            timeout: 4000,
             draggablePercent: 0.4
           }
         )
@@ -371,15 +371,25 @@ export default defineComponent({
       state.isSessionAnswerRequestProcessing = false;
     }
 
-    function submitOmrQuestion(newQuestionIndex: number) {
+    async function submitOmrQuestion(newQuestionIndex: number) {
       const itemResponse = state.responses[newQuestionIndex];
-      SessionAPIService.updateSessionAnswer(
+      const response = await SessionAPIService.updateSessionAnswer( // response.data
         state.sessionId,
         newQuestionIndex,
         {
           answer: itemResponse.answer,
         }
       );
+      if (response.status != 200) {
+        state.toast.error(
+          `Answer for Q.${newQuestionIndex + 1} not saved. Please answer again or refresh the page.`,
+          {
+            position: POSITION.TOP_LEFT,
+            timeout: 4000,
+            draggablePercent: 0.4
+          }
+        )
+      }
     }
 
     async function endTest() {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -277,7 +277,7 @@ export default defineComponent({
     onMounted(() => {
       window.setInterval(() => {
         timerUpdates();
-      }, 80000);
+      }, 8000);
     });
 
     async function startQuiz() {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -42,6 +42,7 @@
         :timeRemaining="timeRemaining"
         v-model:currentQuestionIndex="currentQuestionIndex"
         v-model:responses="responses"
+        v-model:previousOmrResponses="previousOmrResponses"
         @submit-omr-question="submitOmrQuestion"
         @end-test="endTest"
         data-test="omr-modal"
@@ -166,6 +167,7 @@ export default defineComponent({
       questions: [] as Question[],
       responses: [] as SubmittedResponse[], // holds the responses to each item submitted by the viewer
       previousResponse: {} as SubmittedResponse, // holds previous respnose for question being submitted
+      previousOmrResponses: [] as SubmittedResponse[],
       questionSets: [] as QuestionSet[],
       maxQuestionsAllowedToAttempt: 0,
       qsetCumulativeLengths: [] as number[],
@@ -389,6 +391,7 @@ export default defineComponent({
             draggablePercent: 0.4
           }
         )
+        state.responses[newQuestionIndex] = state.previousOmrResponses[newQuestionIndex];
       }
     }
 

--- a/tests/e2e/specs/renders-omr-assessment.js
+++ b/tests/e2e/specs/renders-omr-assessment.js
@@ -17,8 +17,10 @@ describe("Player for OMR quizzes", () => {
         fixture: "new_session_for_multiset_quiz.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
-      cy.intercept("PATCH", "/sessions/*", {});
+      cy.intercept("PATCH", "/session_answers/**", { body: {} }).as(
+        "patchSessionAnswerRequest"
+      );
+      cy.intercept("PATCH", "/sessions/*", { body: { timeRemaining: 100 } });
 
       cy.intercept(
         "GET",
@@ -350,9 +352,10 @@ describe("Player for OMR quizzes", () => {
         fixture: "resume_session_for_multiset_quiz.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
-      cy.intercept("PATCH", "/sessions/*", {});
-
+      cy.intercept("PATCH", "/session_answers/**", { body: {} }).as(
+        "patchSessionAnswerRequest"
+      );
+      cy.intercept("PATCH", "/sessions/*", { body: { timeRemaining: 100 } });
       cy.intercept(
         "GET",
         Cypress.env("backend") + "/organizations/authenticate/*",

--- a/tests/e2e/specs/renders-omr-assessment.js
+++ b/tests/e2e/specs/renders-omr-assessment.js
@@ -150,6 +150,15 @@ describe("Player for OMR quizzes", () => {
           .get('[data-test="endTestButton"]')
           .trigger("click");
 
+        // check if update all session answers request is made
+        cy.wait("@patchSessionAnswerRequest").then((interception) => {
+          const request = interception.request;
+          const response = interception.response;
+
+          expect(request.method).to.equal("PATCH");
+          expect(response.statusCode).to.equal(200);
+        });
+
         // number of skipped questions shown in scorecard
         cy.get('[data-test="scorecard"]')
           .get('[data-test="metricValue-2"]')

--- a/tests/e2e/specs/renders-player-assessment.js
+++ b/tests/e2e/specs/renders-player-assessment.js
@@ -15,8 +15,10 @@ describe("Player for Assessment quizzes", () => {
         fixture: "new_session.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
-      cy.intercept("PATCH", "/sessions/*", {});
+      cy.intercept("PATCH", "/session_answers/**", { body: {} }).as(
+        "patchSessionAnswerRequest"
+      );
+      cy.intercept("PATCH", "/sessions/*", { body: { timeRemaining: 100 } });
 
       cy.intercept(
         "GET",
@@ -89,6 +91,9 @@ describe("Player for Assessment quizzes", () => {
 
           // move back to the previous question
           cy.get('[data-test="modal"]')
+            .get('[data-test="question-index-type')
+            .should("have.text", "Q.2 | Multiple Answer");
+          cy.get('[data-test="modal"]')
             .get('[data-test="previousQuestionButton"]')
             .trigger("click");
 
@@ -148,6 +153,9 @@ describe("Player for Assessment quizzes", () => {
 
         // question 2
         cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.2 | Multiple Answer");
+        cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')
           .trigger("click");
         cy.get('[data-test="modal"]')
@@ -156,6 +164,9 @@ describe("Player for Assessment quizzes", () => {
 
         // question 3
         cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.3 | Multiple Answer");
+        cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')
           .trigger("click");
         cy.get('[data-test="modal"]')
@@ -163,6 +174,9 @@ describe("Player for Assessment quizzes", () => {
           .trigger("click");
 
         // question 4 -- typed but not submitted!
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.4 | Numerical Integer");
         cy.get('[data-test="modal"]')
           .get('[data-test="numericalAnswer"]')
           .type("3");
@@ -378,8 +392,10 @@ describe("Player for Assessment quizzes", () => {
         fixture: "resume_session.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
-      cy.intercept("PATCH", "/sessions/*", {});
+      cy.intercept("PATCH", "/session_answers/**", { body: {} }).as(
+        "patchSessionAnswerRequest"
+      );
+      cy.intercept("PATCH", "/sessions/*", { body: { timeRemaining: 100 } });
 
       cy.intercept(
         "GET",
@@ -426,6 +442,9 @@ describe("Player for Assessment quizzes", () => {
 
         // move back to the previous question
         cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.2 | Multiple Answer");
+        cy.get('[data-test="modal"]')
           .get('[data-test="previousQuestionButton"]')
           .trigger("click");
 
@@ -445,6 +464,9 @@ describe("Player for Assessment quizzes", () => {
           .trigger("click");
 
         // move back to the previous question
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.2 | Multiple Answer");
         cy.get('[data-test="modal"]')
           .get('[data-test="previousQuestionButton"]')
           .trigger("click");

--- a/tests/e2e/specs/renders-player-partial-marks-assessment.js
+++ b/tests/e2e/specs/renders-player-partial-marks-assessment.js
@@ -15,8 +15,10 @@ describe("Player for Assessment quizzes with partial marks", () => {
         fixture: "new_partial_mark_session.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
-      cy.intercept("PATCH", "/sessions/*", {});
+      cy.intercept("PATCH", "/session_answers/**", { body: {} }).as(
+        "patchSessionAnswerRequest"
+      );
+      cy.intercept("PATCH", "/sessions/*", { body: { timeRemaining: 100 } });
 
       cy.intercept(
         "GET",
@@ -50,6 +52,9 @@ describe("Player for Assessment quizzes with partial marks", () => {
           .trigger("click");
 
         // question 2 - skipped; end test
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.2 | Multiple Answer");
         cy.get('[data-test="modal"]')
           .get('[data-test="endTestButton"]')
           .trigger("click");
@@ -112,6 +117,9 @@ describe("Player for Assessment quizzes with partial marks", () => {
           .trigger("click");
 
         // end test
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.2 | Multiple Answer");
         cy.get('[data-test="modal"]')
           .get('[data-test="endTestButton"]')
           .trigger("click");

--- a/tests/e2e/specs/renders-player-to-check-optional.js
+++ b/tests/e2e/specs/renders-player-to-check-optional.js
@@ -16,8 +16,10 @@ describe("Player for Assessment quizzes", () => {
         // of which 3 are answered (first 3 questions in 2nd qset)
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
-      cy.intercept("PATCH", "/sessions/*", {});
+      cy.intercept("PATCH", "/session_answers/**", { body: {} }).as(
+        "patchSessionAnswerRequest"
+      );
+      cy.intercept("PATCH", "/sessions/*", { body: { timeRemaining: 100 } });
 
       cy.intercept(
         "GET",
@@ -49,6 +51,9 @@ describe("Player for Assessment quizzes", () => {
 
         // question 13
         cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.14 | Multiple Answer");
+        cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')
           .trigger("click");
         cy.get('[data-test="modal"]')
@@ -56,6 +61,9 @@ describe("Player for Assessment quizzes", () => {
           .trigger("click");
 
         // question 14
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.15 | Multiple Answer");
         cy.get('[data-test="modal"]')
           .get('[data-test="optionSelector-0"]')
           .trigger("click");
@@ -65,6 +73,9 @@ describe("Player for Assessment quizzes", () => {
       });
 
       it("cannot select answer for question once optional limit reached", () => {
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.16 | Single Choice");
         cy.get('[data-test="togglePaletteButton"]').trigger("click");
         cy.get('[data-test="paletteItem-15"]').trigger("click");
 
@@ -75,6 +86,9 @@ describe("Player for Assessment quizzes", () => {
 
       it("clear answer for already-answered question to attempt different question in optional set", () => {
         // pick 3rd question in 2nd qset
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.16 | Single Choice");
         cy.get('[data-test="togglePaletteButton"]').trigger("click");
         cy.get('[data-test="paletteItem-14"]').trigger("click");
 
@@ -88,6 +102,9 @@ describe("Player for Assessment quizzes", () => {
           .trigger("click");
 
         // now go to 4th question in 2nd qset
+        cy.get('[data-test="modal"]')
+          .get('[data-test="question-index-type')
+          .should("have.text", "Q.16 | Single Choice");
         cy.get('[data-test="togglePaletteButton"]').trigger("click");
         cy.get('[data-test="paletteItem-15"]').trigger("click");
 

--- a/tests/e2e/specs/renders-player-to-check-timed.js
+++ b/tests/e2e/specs/renders-player-to-check-timed.js
@@ -26,7 +26,7 @@ describe("Player for Assessment Timed quizzes", () => {
         fixture: "new_session.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
+      cy.intercept("PATCH", "/session_answers/**", { status: 200 });
       cy.intercept("PATCH", "/sessions/*", { time_remaining: 200 });
 
       cy.intercept(
@@ -166,7 +166,7 @@ describe("Player for Assessment Timed quizzes", () => {
         fixture: "new_session.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
+      cy.intercept("PATCH", "/session_answers/**", { status: 200 });
       cy.intercept("PATCH", "/sessions/*", {});
 
       cy.intercept(
@@ -200,7 +200,7 @@ describe("Player for Assessment Timed quizzes", () => {
         fixture: "resume_session.json",
       });
 
-      cy.intercept("PATCH", "/session_answers/**", {});
+      cy.intercept("PATCH", "/session_answers/**", { status: 200 });
       cy.intercept("PATCH", "/sessions/*", { time_remaining: 1 });
 
       cy.intercept(

--- a/tests/unit/components/Omr/OmrModal.spec.ts
+++ b/tests/unit/components/Omr/OmrModal.spec.ts
@@ -281,10 +281,10 @@ describe("OmrModal.vue", () => {
     });
 
     describe("OMR Assessments", () => {
-      it("sets question index to number of questions upon end test", async () => {
+      it("emits end-test upon end test", async () => {
         wrapper.find('[data-test="endTestButton"]').trigger("click");
         wrapper.find('[data-test="endTestButton"]').trigger("click"); // adding additional click to protect endTest button
-        expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length);
+        expect(wrapper.emitted()).toHaveProperty("end-test");
       });
     });
   });

--- a/tests/unit/components/Questions/Header.spec.ts
+++ b/tests/unit/components/Questions/Header.spec.ts
@@ -7,18 +7,18 @@ describe("Basic tests on Header", () => {
     expect(wrapper).toBeTruthy();
   });
 
-  describe("Title and ID Header",  () => {
+  describe("Title and ID Header", () => {
     it("Student ID Visible", () => {
-      const wrapper = mount (Header, {
-        props: {userId:12345}
+      const wrapper = mount(Header, {
+        props: { userId: "12345" }
       })
       const userIdText = wrapper.find('[data-test="user-id"]').text()
       expect(userIdText).toEqual("Id: 12345")
     })
 
     it("testname Visible", () => {
-      const wrapper = mount (Header, {
-        props: {title:"Mock Test series 1 for All over India for Government school Students by Avanti Fellows NGO"}
+      const wrapper = mount(Header, {
+        props: { title: "Mock Test series 1 for All over India for Government school Students by Avanti Fellows NGO" }
       })
       const testNameElement = wrapper.find('[data-test="test-name"]').text();
       expect(testNameElement).toEqual("Mock Test series 1 for All over India for Government school Students by Avanti Fellows NGO");

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -1,5 +1,5 @@
 import { flushPromises, mount } from "@vue/test-utils";
-import { Question, QuestionSetIndexLimits, SubmittedResponse} from "@/types";
+import { Question, QuestionSetIndexLimits, SubmittedResponse } from "@/types";
 import QuestionModal from "@/components/Questions/QuestionModal.vue";
 import { createQuestionBuckets } from "@/services/Functional/Utilities";
 
@@ -277,10 +277,10 @@ describe("QuestionModal.vue", () => {
           quizType: "assessment",
         });
       });
-      it("sets question index to number of questions upon end test", async () => {
+      it("emits end-test upon end test", async () => {
         wrapper.find('[data-test="endTestButton"]').trigger("click");
         wrapper.find('[data-test="endTestButton"]').trigger("click"); // adding additional click to protect endTest button
-        expect(wrapper.vm.localCurrentQuestionIndex).toBe(questions.length);
+        expect(wrapper.emitted()).toHaveProperty("end-test");
       });
       it("does not increment question index when save & next button is clicked for last question", () => {
         for (let index = 0; index < questions.length - 1; index++) {

--- a/tests/unit/components/Scorecard.spec.ts
+++ b/tests/unit/components/Scorecard.spec.ts
@@ -69,13 +69,13 @@ describe("Scorecard.vue", () => {
   it("should render with default values", () => {
     expect(wrapper).toBeTruthy();
   });
-    it("Student ID Visible", () => {
-      const wrapper = mount (Scorecard, {
-        props: {userId:12345}
-      })
-      const userIdText = wrapper.find('[data-test="user-id"]').text()
-      expect(userIdText).toEqual("Id: 12345")
+  it("Student ID Visible", () => {
+    const wrapper = mount(Scorecard, {
+      props: { userId: "12345" }
     })
+    const userIdText = wrapper.find('[data-test="user-id"]').text()
+    expect(userIdText).toEqual("Id: 12345")
+  })
 
   it("should adjust the radius/stroke of the progress bar according to screen size and orientation", async () => {
     expect(wrapper.vm.circularProgressRadius).toBe(120);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/question-set-player) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/question-set-player#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/style-guide/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #114 

## Summary

This PR makes following changes:
1. Wait for session answer request to return
    - if response is positive, move ahead to next question
    - if response is negative, display error and inform student that their answer is not recorded. Do not record the answer on frontend too (set back to NULL or previously recorded answer)
    - wait for 10 seconds (set timeout in axios instance FOR EVERY request)
2. During request processing time,
    - show a loading spinner on Save & Next / Submit button
    - Disable all other buttons (Previous, Next, Palette, Clear)
    - Pause timer
3. For OMR assessment, since there is no submit button, don't pause for each session answer submission (which happens whenever we select an option). Instead, additionally sync all answers at once when end test is clicked. Display loading spinner beside end-test button and wait until sync is complete. If not complete, display error toast.

Related ADR: https://www.notion.so/avantifellows/ADR-Wait-for-Session-Answer-Response-ce48a939beb240a5b56f5c6035c53931

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [x] Laptop (1200px)
  - [x] Tablet (760px)
  - [x] Phone (320px)
- [x] Cross-Browser Testing
  - [x] Chrome
  - [x] Firefox
- [ ] ~Local Language Support~
- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
  - [ ] ~Added relevant details like Labels/Projects/Milestones etc.~
  - [ ] ~If adding or removing any environment variable, update `docs/ENV.md`, `.env.example` and the Github workflows.~
- [x] Testing
  - [x] Wrote tests
  - [x] Tested locally
  - [x] Tested on staging
  - [x] Tested on an actual physical phone
  - [x] Tested on production
- [ ] ~Lighthouse Checks~
  - [ ] Images have `alt` attributes
  - [ ] Any `<img>` tags have `width` and `height` specified
  - [ ] Any `target="_blank"` links have `rel="noopener"`
  - [ ] Only SVGs are used as images. If PNGs are used, their size has been optimised.
  - [ ] Any SVG buttons without text have their `aria-label` attributes set
