### PR TITLE
Check whether reviewing answers is allowed

### DIFF
--- a/src/components/Questions/Footer.vue
+++ b/src/components/Questions/Footer.vue
@@ -69,6 +69,7 @@
           hidden: isOmrMode
         }"
         v-if="isQuizAssessment && isNextButtonShown"
+        :titleConfig="nextQuestionButtonTitleConfig"
         :iconConfig="nextQuestionButtonIconConfig"
         :buttonClass="assessmentNavigationButtonClass"
         :isDisabled="isSessionAnswerRequestProcessing"
@@ -177,6 +178,11 @@ export default defineComponent({
       iconClass: state.assessmentNavigationButtonIconClass,
     } as IconButtonIconConfig);
 
+    const nextQuestionButtonTitleConfig = ref({
+      value: "Next",
+      class: "text-gray-600",
+    } as IconButtonTitleConfig);
+
     const clearButtonClass = ref([
       state.assessmentTextButtonClass,
       "bg-white hover:bg-gray-50",
@@ -265,6 +271,7 @@ export default defineComponent({
       ...toRefs(state),
       previousQuestionButtonIconConfig,
       nextQuestionButtonIconConfig,
+      nextQuestionButtonTitleConfig,
       clearButtonClass,
       saveAndNextButtonClass,
       clearButtonTitleConfig,

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -168,7 +168,7 @@ export default defineComponent({
       let iconClass = "bg-white hover:bg-gray-200 rounded-lg h-14 w-40 ring-primary px-2 border-b-outset border-primary";
       if (props.hasQuizEnded && !props.reviewAnswers) {
         // only in this case, make the button larger
-        iconClass = "bg-white hover:bg-gray-200 rounded-lg h-24 w-60 ring-primary px-2 border-b-outset border-primary";
+        iconClass = "bg-white hover:bg-gray-200 rounded-lg h-28 w-64 ring-primary px-2 border-b-outset border-primary";
       }
       return iconClass;
     });

--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -59,7 +59,7 @@
       <icon-button
         :titleConfig="startButtonTextConfig"
         :iconConfig="startButtonIconConfig"
-        buttonClass="bg-white hover:bg-gray-200 rounded-lg h-14 w-40  ring-primary px-2 border-b-outset border-primary"
+        :buttonClass="startButtonIconClass"
         class="rounded-2xl shadow-lg mt-4 place-self-center"
         data-test="startQuiz"
         :isDisabled="!isSessionDataFetched"
@@ -105,6 +105,18 @@ export default defineComponent({
       type: Boolean as PropType<isFirstSessionType>,
       default: null,
     },
+    hasQuizEnded: {
+      type: Boolean,
+      default: false
+    },
+    reviewAnswers: {
+      type: Boolean,
+      default: false,
+    },
+    sessionEndTimeText: {
+      type: String,
+      default: ""
+    }
   },
   setup(props, context) {
     const state = reactive({
@@ -133,9 +145,32 @@ export default defineComponent({
         class: "text-lg md:text-xl text-primary font-poppins-bold",
       };
       if (isSessionDataFetched.value) {
-        config.value = props.isFirstSession ? "Let's Start" : "Resume";
+        if (props.isFirstSession) {
+          config.value = "Let's Start";
+        } else {
+          if (props.hasQuizEnded && !props.reviewAnswers) {
+            config.class = "text-sm md:text-sm text-primary font-poppins-bold";
+            config.value = "You cannot review answers now. Please come back after test ends.";
+            if (props.sessionEndTimeText != "") {
+              config.value += ` (${props.sessionEndTimeText})`
+            }
+          } else if (props.hasQuizEnded && props.reviewAnswers) {
+            config.value = "Review";
+          } else {
+            config.value = "Resume";
+          }
+        }
       }
       return config;
+    });
+
+    const startButtonIconClass = computed(() => {
+      let iconClass = "bg-white hover:bg-gray-200 rounded-lg h-14 w-40 ring-primary px-2 border-b-outset border-primary";
+      if (props.hasQuizEnded && !props.reviewAnswers) {
+        // only in this case, make the button larger
+        iconClass = "bg-white hover:bg-gray-200 rounded-lg h-24 w-60 ring-primary px-2 border-b-outset border-primary";
+      }
+      return iconClass;
     });
 
     const startButtonIconConfig = computed(() => {
@@ -154,6 +189,7 @@ export default defineComponent({
       ...toRefs(state),
       displayTitle,
       startButtonTextConfig,
+      startButtonIconClass,
       isSessionDataFetched,
       startButtonIconConfig,
       start,

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface QuizMetadata {
   chapter?: string;
   topic?: string;
   omr_mode: boolean;
+  session_end_time?: string;
 }
 
 export interface QuestionBucket {
@@ -174,6 +175,7 @@ export interface QuizAPIResponse {
   num_graded_questions: number;
   shuffle: boolean;
   time_limit: TimeLimit | null;
+  always_review_answers?: boolean;
   question_sets: QuestionSet[];
 }
 

--- a/tests/unit/components/Splash.spec.ts
+++ b/tests/unit/components/Splash.spec.ts
@@ -38,4 +38,19 @@ describe("Splash.vue", () => {
     await wrapper.find('[data-test="startQuiz"]').trigger("click");
     expect(wrapper.emitted()).toHaveProperty("start");
   });
+
+  it("displays 'Let's Start' when first session", async () => {
+    await wrapper.setProps({ isFirstSession: true });
+    expect(wrapper.find('[data-test="startQuiz"]').text()).toBe("Let's Start");
+  });
+
+  it("displays 'Resume' when not first session and quiz hasn't ended", async () => {
+    await wrapper.setProps({ isFirstSession: false, hasQuizEnded: false });
+    expect(wrapper.find('[data-test="startQuiz"]').text()).toBe("Resume");
+  });
+
+  it("displays 'Review' when quiz has ended and review answers is true", async () => {
+    await wrapper.setProps({ isFirstSession: false, hasQuizEnded: true, reviewAnswers: true });
+    expect(wrapper.find('[data-test="startQuiz"]').text()).toBe("Review");
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/question-set-player) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/question-set-player#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/style-guide/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->
Currently, once the quiz ends, we always display answers.
Some assessments may prefer not displaying answers immediately and waiting for a while.
This initial PR adds facility to block display of answers.

Related ADR: https://www.notion.so/avantifellows/ADR-Session-End-Time-In-Quiz-DB-99d9e6868f7343a18cfb343e916216ec

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
- adds a `reviewAnswers` key -- it is set to `true` by default and remains `true` when `always_review_answers` key from quiz is `true`
- when `always_review_answers` is `false`, we check if current time is greater than `session_end_time` from quiz metadata (if key exists in metadata). If current time is greater, we let users review their answers, and also display correct answers.
- Additionally, "Next" text is added for assessment navigation button (small change)
## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [ ] Test Responsiveness
  - [ ] Laptop (1200px)
  - [ ] Tablet (760px)
  - [ ] Phone (320px)
- [ ] Cross-Browser Testing
  - [ ] Chrome
  - [ ] Firefox
- [ ] ~Local Language Support~
- [ ] Hygiene and Housekeeping
  - [ ] Self-review
  - [ ] Comments have been added appropriately
  - [ ] Check for bundle size [here](https://bundlephobia.com/) if adding a package
  - [ ] Added relevant details like Labels/Projects/Milestones etc.
  - [ ] If adding or removing any environment variable, update `docs/ENV.md`, `.env.example` and the Github workflows.
- [ ] Testing
  - [ ] Wrote tests
  - [ ] Tested locally
  - [ ] Tested on staging
  - [ ] Tested on an actual physical phone
  - [ ] Tested on production
- [ ] Lighthouse Checks
  - [ ] Images have `alt` attributes
  - [ ] Any `<img>` tags have `width` and `height` specified
  - [ ] Any `target="_blank"` links have `rel="noopener"`
  - [ ] Only SVGs are used as images. If PNGs are used, their size has been optimised.
  - [ ] Any SVG buttons without text have their `aria-label` attributes set
