### PR TITLE
Compute time spent per question

### DIFF
--- a/src/components/Omr/OmrModal.vue
+++ b/src/components/Omr/OmrModal.vue
@@ -425,8 +425,7 @@ export default defineComponent({
           _id: response._id,
           question_id: response.question_id,
           answer: response.answer,
-          visited: response.visited,
-          time_spent: response.time_spent
+          visited: response.visited
         }
       )
     })

--- a/src/components/Omr/OmrModal.vue
+++ b/src/components/Omr/OmrModal.vue
@@ -425,7 +425,8 @@ export default defineComponent({
           _id: response._id,
           question_id: response.question_id,
           answer: response.answer,
-          visited: response.visited
+          visited: response.visited,
+          time_spent: response.time_spent
         }
       )
     })

--- a/src/components/Omr/OmrModal.vue
+++ b/src/components/Omr/OmrModal.vue
@@ -387,7 +387,7 @@ export default defineComponent({
           const response = props.responses[qindex];
           if (response.answer != null) numSubmittedResponses += 1
         }
-        if (numSubmittedResponses == questionSetState.maxQuestionsAllowedToAttempt) arr[idx] = true;
+        if (numSubmittedResponses >= questionSetState.maxQuestionsAllowedToAttempt) arr[idx] = true;
       }
 
       return arr;

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -499,7 +499,7 @@ To attempt this question, unselect an answer to another question in this section
         const response = props.responses[idx]
         if (response.answer != null) numSubmittedResponses += 1
       }
-      if (numSubmittedResponses == props.maxQuestionsAllowedToAttempt) return true
+      if (numSubmittedResponses >= props.maxQuestionsAllowedToAttempt) return true
       return false
     })
 

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -50,6 +50,7 @@ export default {
    *                                 This index corresponds to the index of sessionAnswer in session
    * @param {UpdateSessionAnswerAPIPayload} payload - contains the answer {submittedAnswer} that
    * needs to be updated and a boolean variable to indicate that the question is visited
+   * Further, it contains time_spent {number} variable indicating time spent for this question
    * @returns {Promise<SessionAnswerAPIResponse>} - response status of request
    */
   async updateSessionAnswer(
@@ -75,7 +76,7 @@ export default {
   /**
    * @param {string} sessionId - id of the session for which the sessionAnswer is to be updated
    * @param {UpdateAllSessionAnswersAPIPayload} payload - contains list of response objects, each object
-   * includes an answer and whether the corresponding question was visited
+   * includes an answer, whether the corresponding question was visited, and time spent on the question
    * @returns {Promise<SessionAnswerAPIResponse>} - response status of request
    */
   async updateAllSessionAnswers(

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -6,7 +6,7 @@ import {
   UpdateSessionAPIPayload,
   UpdateSessionAPIResponse,
   UpdateSessionAnswerAPIPayload,
-  UpdateAllSessionAnswersAPIPayload
+  UpdateSessionAnswersAtSpecificPositionsAPIPayload
 } from "../../types";
 import axios, { AxiosError } from "axios";
 
@@ -74,18 +74,18 @@ export default {
   },
 
   /**
-   * @param {string} sessionId - id of the session for which the sessionAnswer is to be updated
-   * @param {UpdateAllSessionAnswersAPIPayload} payload - contains list of response objects, each object
-   * includes an answer, whether the corresponding question was visited, and time spent on the question
-   * @returns {Promise<SessionAnswerAPIResponse>} - response status of request
-   */
-  async updateAllSessionAnswers(
+ * @param {string} sessionId - id of the session for which the sessionAnswers are to be updated at specific positions
+ * @param {UpdateSessionAnswersAtSpecificPositionsAPIPayload} payload - contains list of response objects, each object
+ * includes a position, an answer, whether the corresponding question was visited, and time spent on the question
+ * @returns {Promise<SessionAnswerAPIResponse>} - response status of request
+ */
+  async updateSessionAnswersAtSpecificPositions(
     sessionId: string,
-    payload: UpdateAllSessionAnswersAPIPayload
+    payload: UpdateSessionAnswersAtSpecificPositionsAPIPayload
   ): Promise<SessionAnswerAPIResponse> {
     try {
       const response = await apiClient().patch(
-        sessionAnswersEndpoint + sessionId,
+        `${sessionAnswersEndpoint}${sessionId}/update-multiple-answers`,
         payload
       );
       return { status: response.status };
@@ -96,5 +96,5 @@ export default {
         return { status: 400 }; // bad request
       }
     }
-  },
+  }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export interface SubmittedResponse {
   question_id: string;
   answer: submittedAnswer;
   visited: boolean;
-  time_spent?: number; // time spent per question in seconds
+  time_spent?: number; // time spent on question in seconds
 }
 
 interface ScorecardMetricIcon {
@@ -206,10 +206,15 @@ export interface SessionAnswerAPIResponse {
 export interface UpdateSessionAnswerAPIPayload {
   answer?: submittedAnswer;
   visited?: boolean;
-  time_spent?: number; // time spent per question in seconds
+  time_spent?: number; // time spent on question in seconds
 }
 
-export interface UpdateAllSessionAnswersAPIPayload extends Array<UpdateSessionAnswerAPIPayload> {}
+export type TimeSpentEntry = {
+  timeSpent: number;
+  hasSynced: boolean;
+};
+
+export type UpdateSessionAnswersAtSpecificPositionsAPIPayload = [number, UpdateSessionAnswerAPIPayload][];
 
 export interface answerEvaluation {
   valid: boolean; // whether the evaluation of the question is valid in the first place (invalid for ungraded questions)

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface SubmittedResponse {
   question_id: string;
   answer: submittedAnswer;
   visited: boolean;
+  time_spent?: number; // time spent per question in seconds
 }
 
 interface ScorecardMetricIcon {
@@ -205,6 +206,7 @@ export interface SessionAnswerAPIResponse {
 export interface UpdateSessionAnswerAPIPayload {
   answer?: submittedAnswer;
   visited?: boolean;
+  time_spent?: number; // time spent per question in seconds
 }
 
 export interface UpdateAllSessionAnswersAPIPayload extends Array<UpdateSessionAnswerAPIPayload> {}

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -372,7 +372,7 @@ export default defineComponent({
     onMounted(() => {
       window.setInterval(() => {
         timerUpdates();
-      }, 8000);
+      }, 20000);
     });
 
     async function startQuiz() {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -259,7 +259,7 @@ export default defineComponent({
       (newValue, oldValue) => {
         stopTimeSpentPerQuestionCalc();
         if (!state.hasQuizEnded && isQuizAssessment.value && !isOmrMode.value && oldValue != -1) {
-          // update time spent for previous question in assessment (but not omr)
+          // update time spent for previous question in assessment
           // but not for homework
           SessionAPIService.updateSessionAnswer(
             state.sessionId,

--- a/tests/e2e/fixtures/new_homework_session.json
+++ b/tests/e2e/fixtures/new_homework_session.json
@@ -1,0 +1,30 @@
+{
+    "_id": "62625e0f773b5fb92fde890b",
+    "user_id": "1",
+    "quiz_id": "abcd",
+    "has_quiz_ended": false,
+    "is_first": true,
+    "session_answers": [
+      {
+          "_id": "62a37b95c54e0efc5c53d4f6",
+          "question_id": "6285554a1016dc7050373fbf",
+          "answer": null,
+          "visited": false,
+          "time_spent": null
+      },
+      {
+          "_id": "62a37b95c54e0efc5c53d4f7",
+          "question_id": "6285554a1016dc7050373fc0",
+          "answer": null,
+          "visited": false,
+          "time_spent": null
+      },
+      {
+          "_id": "62a37b95c54e0efc5c53d4f8",
+          "question_id": "6285554a1016dc7050373fc1",
+          "answer": null,
+          "visited": false,
+          "time_spent": null
+      }
+    ]
+  }

--- a/tests/e2e/specs/renders-omr-assessment.js
+++ b/tests/e2e/specs/renders-omr-assessment.js
@@ -31,8 +31,12 @@ describe("Player for OMR quizzes", () => {
       );
       cy.visit("/quiz/abcd?userId=1&apiKey=pqr");
 
+      cy.server();
+      cy.clock();
+
       // define aliasas
       cy.get('[data-test="startQuiz"]').as("startQuizButton");
+      cy.route("PATCH", "/session_answers/**").as("patch_session_answers");
     });
 
     it("shows splash screen", () => {
@@ -79,6 +83,22 @@ describe("Player for OMR quizzes", () => {
             .get('[data-test="OmrItem-0"]')
             .within(() => {
               cy.get('[data-test="optionSelector-0"]').trigger("click");
+            });
+        });
+
+        it("does not contain time_spent in patch session answer request", () => {
+          cy.wait("@patch_session_answers");
+          cy.get("@patch_session_answers")
+            .its("request.body")
+            .should("deep.equal", {
+              visited: true,
+            });
+
+          cy.wait("@patch_session_answers");
+          cy.get("@patch_session_answers")
+            .its("request.body")
+            .should("deep.equal", {
+              answer: [0],
             });
         });
 

--- a/tests/unit/components/Omr/OmrModal.spec.ts
+++ b/tests/unit/components/Omr/OmrModal.spec.ts
@@ -236,6 +236,7 @@ describe("OmrModal.vue", () => {
       question_id: question._id,
       answer: null,
       visited: false,
+      time_spent: 0
     })
   );
 
@@ -323,6 +324,7 @@ describe("OmrModal.vue", () => {
           question_id: questions[questionIndex]._id,
           answer: [0],
           visited: false,
+          time_spent: 0
         });
         expect(wrapper.emitted()).toHaveProperty("submit-omr-question");
       });
@@ -413,6 +415,7 @@ describe("OmrModal.vue", () => {
           question_id: questions[questionIndex]._id,
           answer: [0, 1],
           visited: false,
+          time_spent: 0
         });
         expect(wrapper.emitted()).toHaveProperty("submit-omr-question");
       });

--- a/tests/unit/components/Questions/QuestionModal.spec.ts
+++ b/tests/unit/components/Questions/QuestionModal.spec.ts
@@ -218,6 +218,7 @@ describe("QuestionModal.vue", () => {
       question_id: question._id,
       answer: null,
       visited: false,
+      time_spent: 0
     })
   );
 
@@ -471,6 +472,7 @@ describe("QuestionModal.vue", () => {
           question_id: questions[questionIndex]._id,
           answer: [0],
           visited: false,
+          time_spent: 0
         });
         expect(wrapper.emitted()).toHaveProperty("submit-question");
       });
@@ -572,6 +574,7 @@ describe("QuestionModal.vue", () => {
           question_id: questions[questionIndex]._id,
           answer: [0, 1],
           visited: false,
+          time_spent: 0
         });
         expect(wrapper.emitted()).toHaveProperty("submit-question");
       });
@@ -653,6 +656,7 @@ describe("QuestionModal.vue", () => {
             question_id: questions[questionIndex]._id,
             answer,
             visited: false,
+            time_spent: 0
           });
           expect(wrapper.emitted()).toHaveProperty("submit-question");
         });
@@ -754,6 +758,7 @@ describe("QuestionModal.vue", () => {
             question_id: questions[questionIndex]._id,
             answer,
             visited: false,
+            time_spent: 0
           });
           expect(wrapper.emitted()).toHaveProperty("submit-question");
         });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/question-set-player) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/question-set-player#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/style-guide/.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #123 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
- Computes time spent on each question for homework and assessment types
- For OMR assessment, we ignore this computation.

We maintain an array `timeSpentPerQuestion[]` that has a length of `numQuestions`. 

For each question in homework,
- timer starts when question is opened (via Start/Resume/Continue buttons)
- timer stops when answer is submitted (Submit button) or when back button is clicked.
- `time_spent` is sent to backend with "Submit" button is clicked.

For each question in assessment,
- timer starts when question is opened (via Start/Resume/Back/Next/Palette buttons)
- timer stops when navigated to another question
- `time_spent` is sent to backend when Save & Next button is clicked. 

In addition, we also send an update on `time_spent` on each question to backend every few seconds, along with `dummy-event`. This helps keep track of the latest values of `timeSpentPerQuestion` (in case submit or save buttons are not clicked). 

Related ADR: https://www.notion.so/avantifellows/ADR-Time-Spent-Per-Question-211b3f4088894f8b96b471a787c2f073

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [x] Laptop (1200px)
  - [x] Tablet (760px)
  - [x] Phone (320px)
- [x] Cross-Browser Testing
  - [x] Chrome
  - [x] Firefox
- [ ] ~Local Language Support~
- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
  - [ ] ~Added relevant details like Labels/Projects/Milestones etc.~
  - [ ] ~If adding or removing any environment variable, update `docs/ENV.md`, `.env.example` and the Github workflows.~
- [x] Testing
  - [x] Wrote tests
  - [x] Tested locally
  - [x] Tested on staging
  - [x] Tested on an actual physical phone
  - [ ] Tested on production
- [ ] ~Lighthouse Checks~
  - [ ] ~Images have `alt` attributes~
  - [ ] ~Any `<img>` tags have `width` and `height` specified~
  - [ ] ~Any `target="_blank"` links have `rel="noopener"`~
  - [ ] ~Only SVGs are used as images. If PNGs are used, their size has been optimised.~
  - [ ] ~Any SVG buttons without text have their `aria-label` attributes set~
