### PR TITLE
Display solutions in assessments

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -218,6 +218,14 @@
           </div>
         </div>
       </div>
+      <!-- Solution container -->
+        <div
+          v-if="hasQuizEnded && $props.displaySolution && isSolutionTextPresent"
+          class="mx-6 md:mx-10 py-4"
+        >
+          <p class="text-lg base:text-lg font-bold">Solution:</p>
+          <p :class="solutionTextClass" data-test="solution-text" v-html="solutionText"></p>
+        </div>
     </div>
   </div>
 </template>
@@ -248,6 +256,10 @@ export default defineComponent({
   },
   props: {
     text: {
+      default: "",
+      type: String
+    },
+    solutionText: {
       default: "",
       type: String
     },
@@ -291,6 +303,10 @@ export default defineComponent({
     imageData: {
       default: null,
       type: Object
+    },
+    displaySolution: {
+      default: true,
+      type: Boolean
     },
     isPortrait: {
       default: false,
@@ -382,6 +398,8 @@ export default defineComponent({
         "float-right text-lg sm:text-xl mx-4 m-2 text-right leading-tight whitespace-pre-wrap text-base",
       questionTextClass:
         "text-lg base:text-lg lg:text-xl mx-4 mt-6 m-2 font-bold leading-tight whitespace-pre-wrap",
+      solutionTextClass:
+      "p-2 text-base base:text-lg lg:text-xl border border-black mx-2 whitespace-pre-wrap",
       optionTextClass:
         "p-2 text-base base:text-lg lg:text-xl border rounded-md mx-2 whitespace-pre-wrap",
       subjectiveAnswer: null as string | null, // holds the answer to the subjective question
@@ -571,6 +589,9 @@ export default defineComponent({
     )
     const areOptionsVisible = computed(() =>
       state.questionTypesWithOptions.has(props.questionType)
+    )
+    const isSolutionTextPresent = computed(
+      () => props.solutionText != ""
     )
     const isQuestionTypeSubjective = computed(
       () => props.questionType == questionType.SUBJECTIVE
@@ -782,6 +803,7 @@ export default defineComponent({
       questionHeaderPrefix,
       questionHeaderSuffix,
       stopImageLoading,
+      isSolutionTextPresent,
       optionBackgroundClass,
       isOptionMarked,
       selectOption,

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -399,7 +399,7 @@ export default defineComponent({
       questionTextClass:
         "text-lg base:text-lg lg:text-xl mx-4 mt-6 m-2 font-bold leading-tight whitespace-pre-wrap",
       solutionTextClass:
-      "p-2 text-base base:text-lg lg:text-xl border border-black mx-2 whitespace-pre-wrap",
+      "p-2 text-base base:text-lg lg:text-xl mx-2 whitespace-pre-wrap",
       optionTextClass:
         "p-2 text-base base:text-lg lg:text-xl border rounded-md mx-2 whitespace-pre-wrap",
       subjectiveAnswer: null as string | null, // holds the answer to the subjective question

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -33,6 +33,7 @@
     >
       <Body
         :text="currentQuestion.text"
+        :solutionText="currentQuestion.solution"
         :class="bodyContainerClass"
         :options="currentQuestion.options"
         :correctAnswer="questionCorrectAnswer"
@@ -42,6 +43,7 @@
         :matrixSize="currentQuestion.matrix_size"
         :isPortrait="isPortrait"
         :imageData="currentQuestion?.image"
+        :displaySolution="displaySolution"
         :draftAnswer="draftResponses[currentQuestionIndex]"
         :submittedAnswer="currentQuestionResponseAnswer"
         :isAnswerSubmitted="isAnswerSubmitted"
@@ -201,6 +203,10 @@ export default defineComponent({
       type: [null, String] as PropType<testFormat>,
       required: true
     },
+    displaySolution: {
+      type: Boolean,
+      default: true
+    }
   },
   setup(props, context) {
     const state = reactive({

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,7 @@ export interface QuizAPIResponse {
   shuffle: boolean;
   time_limit: TimeLimit | null;
   review_immediate?: boolean;
+  display_solution?: boolean;
   question_sets: QuestionSet[];
 }
 

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -24,6 +24,7 @@
         :maxMarks="maxMarks"
         :maxQuestionsAllowedToAttempt="maxQuestionsAllowedToAttempt"
         :testFormat="metadata.test_format || ''"
+        :displaySolution="displaySolution"
         :questions="questions"
         :questionSetStates="questionSetStates"
         @start="startQuiz"
@@ -207,6 +208,7 @@ export default defineComponent({
       isScorecardShown: false, // to show the scorecard or not
       hasQuizEnded: false, // whether the quiz has ended - only valid for quizType = assessment
       reviewAnswers: true, // whether users can review answers once quiz has ended
+      displaySolution: true as boolean, // whether solutions to each question should be displayed
       sessionEndTimeText: "", // session end time in text if available
       sessionId: "", // id of the session created for a user-quiz combination
       isSessionAnswerRequestProcessing: false, // whether session answer api request is processing
@@ -426,6 +428,7 @@ export default defineComponent({
       state.maxMarks =
         quizDetails.max_marks || quizDetails.num_graded_questions;
       state.title = quizDetails.title;
+      state.displaySolution = quizDetails?.display_solution ?? true;
       createQuestionBuckets(totalQuestionsInEachSet);
 
       if (quizDetails?.review_immediate == false) {


### PR DESCRIPTION
Fixes #143

## Summary

If `display_solution` is true and quiz has ended, we display solutions in `Body` for assessments.

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- [x] Test Responsiveness
  - [x] Laptop (1200px)
  - [x] Tablet (760px)
  - [x] Phone (320px)
- [x] Cross-Browser Testing
  - [x] Chrome
  - [x] Firefox
- [ ] ~Local Language Support~
- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
  - [ ] ~Added relevant details like Labels/Projects/Milestones etc.~
  - [ ] ~If adding or removing any environment variable, update `docs/ENV.md`, `.env.example` and the Github workflows.~
- [x] Testing
  - [ ] ~Wrote tests~
  - [x] Tested locally
  - [x] Tested on staging
  - [x] Tested on an actual physical phone
  - [x] Tested on production
- [ ] ~Lighthouse Checks~
  - [ ] Images have `alt` attributes
  - [ ] Any `<img>` tags have `width` and `height` specified
  - [ ] Any `target="_blank"` links have `rel="noopener"`
  - [ ] Only SVGs are used as images. If PNGs are used, their size has been optimised.
  - [ ] Any SVG buttons without text have their `aria-label` attributes set
