### PR TITLE
Fix issue #160 [C4GT Community]: Reduce text area and increase numerical answer fontsize 

### DIFF
--- a/src/components/Omr/OmrItem.vue
+++ b/src/components/Omr/OmrItem.vue
@@ -107,7 +107,7 @@
             v-model:value="numericalAnswer"
             class="px-1 w-full text-lg"
             :boxStyling="numericalAnswerBoxStyling"
-            placeholder="Only numbers are allowed"
+            placeholder="Numbers only."
             :inputMode="getInputMode"
             :isDisabled="isAnswerDisabled"
             :maxHeightLimit="50"

--- a/src/components/Omr/OmrItem.vue
+++ b/src/components/Omr/OmrItem.vue
@@ -105,12 +105,12 @@
           <!-- input area for the answer -->
           <Textarea
             v-model:value="numericalAnswer"
-            class="px-1 w-full"
+            class="px-1 w-full text-lg"
             :boxStyling="numericalAnswerBoxStyling"
             placeholder="Only numbers are allowed"
             :inputMode="getInputMode"
             :isDisabled="isAnswerDisabled"
-            :maxHeightLimit="250"
+            :maxHeightLimit="50"
             @beforeinput="preventKeypressIfApplicable"
             data-test="numericalAnswer"
           ></Textarea>
@@ -749,7 +749,7 @@ export default defineComponent({
           (isAnswerSubmitted.value && !props.isGradedQuestion) ||
           (isQuizAssessment.value && !props.hasQuizEnded),
       },
-      "bp-420:h-12 sm:h-12 md:h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
+      "h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
     ]);
 
     state.subjectiveAnswer = defaultSubjectiveAnswer.value;

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -154,12 +154,12 @@
           <!-- input area for the answer -->
           <Textarea
             v-model:value="numericalAnswer"
-            class="px-2 w-full"
+            class="px-2 w-full text-base"
             :boxStyling="numericalAnswerBoxStyling"
-            placeholder="Enter your answer here. Only numbers are allowed"
+            placeholder="Enter your answer here. Numbers only"
             :inputMode="getInputMode"
             :isDisabled="isAnswerDisabled"
-            :maxHeightLimit="250"
+            :maxHeightLimit="50"
             @beforeinput="preventKeypressIfApplicable"
             data-test="numericalAnswer"
           ></Textarea>
@@ -901,7 +901,7 @@ export default defineComponent({
           (props.isAnswerSubmitted && !props.isGradedQuestion) ||
           (isQuizAssessment.value && !props.hasQuizEnded),
       },
-      "bp-420:h-20 sm:h-28 md:h-36 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
+      "h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
     ]);
 
     state.subjectiveAnswer = defaultSubjectiveAnswer.value;

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -156,7 +156,7 @@
             v-model:value="numericalAnswer"
             class="px-2 w-full text-base"
             :boxStyling="numericalAnswerBoxStyling"
-            placeholder="Enter your answer here. Numbers only"
+            placeholder="Enter your answer here. Numbers only."
             :inputMode="getInputMode"
             :isDisabled="isAnswerDisabled"
             :maxHeightLimit="50"


### PR DESCRIPTION
Fixes #160 
The textarea height has been reduced and text font size been adjusted accordingly for numerical input answer.

Desktop view:
![Screenshot from 2024-09-09 13-21-39](https://github.com/user-attachments/assets/27cc0681-86ff-4ed7-afda-fcbda219295e)

Mobile view:
![Screenshot from 2024-09-09 13-21-18](https://github.com/user-attachments/assets/00f3f854-f803-4d91-a8ed-fde980f22825)




