### PR TITLE
Update Splash.vue

### DIFF
--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -23,6 +23,14 @@
               <p :class="metadataTitleClass">{{ numQuestions }} questions</p>
             </div>
           </div>
+          <!-- Conditional check for grade -->
+          <div v-if="grade" :class="metadataCellClass">
+            <BaseIcon name="student-in-class" :iconClass="metadataIconClass"></BaseIcon>
+            <div class="flex items-center" data-test="grade">
+              <p :class="metadataTitleClass">Class {{ grade }}</p>
+            </div>
+          </div>
+        </div>      
           <div :class="metadataCellClass">
             <BaseIcon
               name="student-in-class"


### PR DESCRIPTION
Fixes #158 

## Summary

To solve this issue, I have applied conditional rendering using Vue.js's v-if directive. The problem was that the "Class" information was being displayed even when the grade field was missing. To address this:

I wrapped the "Class" field display inside a v-if="grade" condition.
This ensures that the "Class" field is only rendered when the grade data is available from the backend.
If grade is missing, the field will be hidden, preventing empty or misleading information from appearing in the UI. By using above approach I have tried to solve the issue. If it is correct may I raise a Pull Request.
