### PR TITLE
enhancement:Default metadata is shown on Splash if it does not exist

### DIFF
--- a/src/components/Splash.vue
+++ b/src/components/Splash.vue
@@ -30,7 +30,7 @@
             ></BaseIcon>
 
             <div class="flex items-center" data-test="grade">
-              <p :class="metadataTitleClass">Class {{ grade }}</p>
+              <p :class="metadataTitleClass">Class {{ grade || ": ..."}}</p>
             </div>
           </div>
         </div>
@@ -39,7 +39,7 @@
           <div :class="metadataCellClass" class="border-r-2">
             <BaseIcon name="math" :iconClass="metadataIconClass"></BaseIcon>
             <div class="flex items-center" data-test="subject">
-              <p :class="metadataTitleClass">{{ subject }}</p>
+              <p :class="metadataTitleClass">{{ subject || "Subject: ..." }}</p>
             </div>
           </div>
           <div :class="metadataCellClass">


### PR DESCRIPTION
Fixes the issue [#{158}](https://github.com/avantifellows/quiz-frontend/issues/158)

## Summary

Some times, quiz or assessment data may lack fields like "grade" and "subject." To ensure that the splash screen doesn’t appear empty, we use default values such as "Class: ..." and "Subject: ..." as placeholders. This allows us to verify the screen's appearance even when data is missing.

![image](https://github.com/user-attachments/assets/6d4e4efc-9680-41f2-bf42-a6725d4006a7)


**_Note:_** Only the values of Class(Grade) and Subject are being assigned default values



