### PR TITLE
disabled copy-paste functionality for questions in the quiz assesment

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -36,7 +36,7 @@
         ></p>
       </div>
       <!-- question text -->
-      <div class="mx-6 md:mx-10">
+      <div class="mx-6 md:mx-10" v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
         <p :class="questionTextClass" data-test="text" v-html="text"></p>
       </div>
       <div :class="orientationClass">
@@ -52,7 +52,7 @@
           />
         </div>
         <!-- question image container -->
-        <div :class="questionImageContainerClass" v-if="isQuestionImagePresent">
+        <div :class="questionImageContainerClass" v-if="isQuestionImagePresent" v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
           <img
             :src="imageData.url"
             class="object-contain h-full w-full"
@@ -97,6 +97,7 @@
                     v-html="option.text"
                     class="ml-2 h-full place-self-center text-base sm:text-lg"
                     :data-test="`option-${optionIndex}`"
+                    v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}"
                   ></div>
                 </label>
               </div>


### PR DESCRIPTION
Fixes #{issue id}

## Feature:

Conditional Copying Behavior:

1. Copying is disabled if the quiz has not ended.
2. Copying is enabled if the quiz has ended or if the assessment is not of the quiz type.

## Summary

We’ve disabled copying questions by using the HTML inert attribute to help prevent malpractices like copying and searching for answers online.

Added the attribute to the question div, question image div, and options text div.1
Note : The radio buttons in options is not obstructed by inert!

