### PR TITLE
feat:shuffle the question in quiz assesments!

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -1,39 +1,18 @@
 <template>
-  <div
-    class="flex relative h-full overflow-y-auto"
-    :class="{ 'bg-gray-50': isPaletteVisible }"
-  >
-    <QuestionPalette
-      v-if="isPaletteVisible"
-      :hasQuizEnded="hasQuizEnded"
-      :questionSetStates="questionSetStates"
-      :currentQuestionIndex="currentQuestionIndex"
-      :title="title"
-      :subject="subject"
-      :testFormat="testFormat"
-      :maxMarks="maxMarks"
-      :numQuestions="numQuestions"
-      :quizTimeLimit="quizTimeLimit"
-      class="absolute w-full h-full sm:w-2/3 lg:w-1/2 xl:w-1/3 z-10"
-      @navigate="navigateToQuestion"
-      data-test="questionPalette"
-    >
+  <div class="flex relative h-full overflow-y-auto" :class="{ 'bg-gray-50': isPaletteVisible }">
+    <QuestionPalette v-if="isPaletteVisible" :hasQuizEnded="hasQuizEnded" :questionSetStates="questionSetStates"
+      :currentQuestionIndex="currentQuestionIndex" :title="title" :subject="subject" :testFormat="testFormat"
+      :maxMarks="maxMarks" :numQuestions="numQuestions" :quizTimeLimit="quizTimeLimit"
+      class="absolute w-full h-full sm:w-2/3 lg:w-1/2 xl:w-1/3 z-10" @navigate="navigateToQuestion"
+      data-test="questionPalette">
     </QuestionPalette>
 
     <div class="overflow-y-auto flex flex-col w-full">
       <div class="bg-gray-300">
         <!-- questionHeaderPrefix shows the question index no. and the type of question -->
-        <p
-          :class="questionHeaderPrefixClass"
-          data-test="question-index-type"
-          v-html="questionHeaderPrefix"
-        ></p>
+        <p :class="questionHeaderPrefixClass" data-test="question-index-type" v-html="questionHeaderPrefix"></p>
         <!-- questionHeaderSuffix shows the subject and section no. of question -->
-        <p
-          :class="questionHeaderSuffixClass"
-          data-test="question-subject-section"
-          v-html="questionHeaderSuffix"
-        ></p>
+        <p :class="questionHeaderSuffixClass" data-test="question-subject-section" v-html="questionHeaderSuffix"></p>
       </div>
       <!-- question text -->
       <div class="mx-6 md:mx-10" v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
@@ -41,145 +20,75 @@
       </div>
       <div :class="orientationClass">
         <!-- loading spinner when question image is loading -->
-        <div
-          :class="questionImageAreaClass"
-          class="flex justify-center"
-          v-if="isImageLoading"
-        >
-          <BaseIcon
-            name="spinner-solid"
-            iconClass="animate-spin h-4 w-4 object-scale-down"
-          />
+        <div :class="questionImageAreaClass" class="flex justify-center" v-if="isImageLoading">
+          <BaseIcon name="spinner-solid" iconClass="animate-spin h-4 w-4 object-scale-down" />
         </div>
         <!-- question image container -->
-        <div :class="questionImageContainerClass" v-if="isQuestionImagePresent" v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
-          <img
-            :src="imageData.url"
-            class="object-contain h-full w-full"
-            :alt="imageData.alt_text"
-            @load="stopImageLoading"
-            ref="questionImage"
-            :class="{ invisible: isImageLoading }"
-          />
+        <div :class="questionImageContainerClass" v-if="isQuestionImagePresent"
+          v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
+          <img :src="imageData.url" class="object-contain h-full w-full" :alt="imageData.alt_text"
+            @load="stopImageLoading" ref="questionImage" :class="{ invisible: isImageLoading }" />
         </div>
         <!-- option container -->
-        <div
-          v-if="areOptionsVisible"
-          class="flex"
-          :class="answerContainerClass"
-          data-test="optionContainer"
-        >
+        <div v-if="areOptionsVisible" class="flex" :class="answerContainerClass" data-test="optionContainer">
           <ul class="w-full">
             <li class="list-none space-y-1 flex flex-col">
-              <div
-                v-for="(option, optionIndex) in options"
-                :key="optionIndex"
+              <div v-for="(option, optionIndex) in options" :key="optionIndex"
                 :class="[optionBackgroundClass(optionIndex), optionTextClass]"
-                :data-test="`optionContainer-${optionIndex}`"
-              >
+                :data-test="`optionContainer-${optionIndex}`">
                 <!-- each option is defined here -->
                 <!-- adding <label> so that touch input is just not limited to the radio/checkbox button -->
                 <label :class="labelClass(option)">
                   <!-- understand the meaning of the attributes here:
                     https://www.w3schools.com/tags/att_input_type_radio.asp -->
 
-                  <input
-                    :type="optionInputType"
-                    name="option"
+                  <input :type="optionInputType" name="option"
                     class="place-self-center text-primary focus:ring-0 disabled:cursor-not-allowed"
-                    style="box-shadow: none"
-                    @click="selectOption(optionIndex)"
-                    :checked="isOptionMarked(optionIndex)"
-                    :disabled="isAnswerDisabled"
-                    :data-test="`optionSelector-${optionIndex}`"
-                  />
-                  <div
-                    v-html="option.text"
-                    class="ml-2 h-full place-self-center text-base sm:text-lg"
+                    style="box-shadow: none" @click="selectOption(optionIndex)" :checked="isOptionMarked(optionIndex)"
+                    :disabled="isAnswerDisabled" :data-test="`optionSelector-${optionIndex}`" />
+                  <div v-html="option.text" class="ml-2 h-full place-self-center text-base sm:text-lg"
                     :data-test="`option-${optionIndex}`"
-                    v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}"
-                  ></div>
+                    v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}"></div>
                 </label>
               </div>
             </li>
           </ul>
         </div>
         <!-- subjective question answer -->
-        <div
-          v-if="isQuestionTypeSubjective"
-          class="flex flex-col"
-          :class="answerContainerClass"
-          data-test="subjectiveAnswerContainer"
-        >
+        <div v-if="isQuestionTypeSubjective" class="flex flex-col" :class="answerContainerClass"
+          data-test="subjectiveAnswerContainer">
           <!-- input area for the answer -->
-          <Textarea
-            v-model:value="subjectiveAnswer"
-            class="px-2 w-full"
-            :boxStyling="subjectiveAnswerBoxStyling"
-            placeholder="Enter your answer here"
-            :isDisabled="isAnswerDisabled"
-            :maxHeightLimit="250"
-            @beforeinput="preventKeypressIfApplicable"
-            data-test="subjectiveAnswer"
-          ></Textarea>
+          <Textarea v-model:value="subjectiveAnswer" class="px-2 w-full" :boxStyling="subjectiveAnswerBoxStyling"
+            placeholder="Enter your answer here" :isDisabled="isAnswerDisabled" :maxHeightLimit="250"
+            @beforeinput="preventKeypressIfApplicable" data-test="subjectiveAnswer"></Textarea>
           <!-- character limit -->
-          <div
-            class="flex items-end px-6 mt-2"
-            v-if="hasCharLimit && !isAnswerSubmitted"
-            data-test="charLimitContainer"
-          >
-            <p
-              class="text-sm sm:text-base lg:text-lg font-bold"
-              :class="maxCharLimitClass"
-              data-test="charLimit"
-            >
+          <div class="flex items-end px-6 mt-2" v-if="hasCharLimit && !isAnswerSubmitted"
+            data-test="charLimitContainer">
+            <p class="text-sm sm:text-base lg:text-lg font-bold" :class="maxCharLimitClass" data-test="charLimit">
               {{ charactersLeft }} characters left
             </p>
           </div>
           <!-- answer display -->
-          <div
-            v-if="hasQuizEnded"
-            class="px-2 text-lg mt-2"
-            data-test="subjectiveCorrectAnswer"
-          >
+          <div v-if="hasQuizEnded" class="px-2 text-lg mt-2" data-test="subjectiveCorrectAnswer">
             Correct Answer: {{ correctAnswer }}
           </div>
         </div>
         <!-- Numerical question answer -->
-        <div
-          v-if="isQuestionTypeNumericalFloat || isQuestionTypeNumericalInteger"
-          class="flex flex-col"
-          :class="answerContainerClass"
-          data-test="numericalAnswerContainer"
-        >
+        <div v-if="isQuestionTypeNumericalFloat || isQuestionTypeNumericalInteger" class="flex flex-col"
+          :class="answerContainerClass" data-test="numericalAnswerContainer">
           <!-- input area for the answer -->
-          <Textarea
-            v-model:value="numericalAnswer"
-            class="px-2 w-full text-base"
-            :boxStyling="numericalAnswerBoxStyling"
-            placeholder="Enter your answer here. Numbers only."
-            :inputMode="getInputMode"
-            :isDisabled="isAnswerDisabled"
-            :maxHeightLimit="50"
-            @beforeinput="preventKeypressIfApplicable"
-            data-test="numericalAnswer"
-          ></Textarea>
+          <Textarea v-model:value="numericalAnswer" class="px-2 w-full text-base"
+            :boxStyling="numericalAnswerBoxStyling" placeholder="Enter your answer here. Numbers only."
+            :inputMode="getInputMode" :isDisabled="isAnswerDisabled" :maxHeightLimit="50"
+            @beforeinput="preventKeypressIfApplicable" data-test="numericalAnswer"></Textarea>
           <!-- answer display -->
-          <div
-            v-if="hasQuizEnded"
-            class="px-2 text-lg mt-2"
-            data-test="numericalCorrectAnswer"
-          >
+          <div v-if="hasQuizEnded" class="px-2 text-lg mt-2" data-test="numericalCorrectAnswer">
             Correct Answer: {{ correctAnswer }}
           </div>
         </div>
         <!-- Matrix match answer -->
-        <div
-          v-if="isQuestionTypeMatrixMatch"
-          class="flex flex-col items-center"
-          :class="answerContainerClass"
-          data-test="matrixMatchContainer"
-        >
+        <div v-if="isQuestionTypeMatrixMatch" class="flex flex-col items-center" :class="answerContainerClass"
+          data-test="matrixMatchContainer">
           <ul class="max-w-screen-md w-full">
             <li class="list-none space-y-1 flex flex-col">
               <!-- Create the matrix match table -->
@@ -187,74 +96,49 @@
                 <thead>
                   <tr>
                     <th></th>
-                    <th
-                      v-for="(column, columnIndex) in $props.matrixSize?.[1] ||
-                      5"
-                      :key="columnIndex"
-                      class="border border-gray-200 text-center"
-                    >
+                    <th v-for="(column, columnIndex) in $props.matrixSize?.[1] ||
+                      5" :key="columnIndex" class="border border-gray-200 text-center">
                       {{ getColumnLabel(columnIndex) }}
                     </th>
                   </tr>
                 </thead>
                 <tbody>
-                  <tr
-                    v-for="(row, rowIndex) in $props.matrixSize?.[0] || 4"
-                    :key="rowIndex"
-                  >
+                  <tr v-for="(row, rowIndex) in $props.matrixSize?.[0] || 4" :key="rowIndex">
                     <td class="border border-gray-200 text-center">
                       {{ getRowLabel(rowIndex) }}
                     </td>
-                    <td
-                      v-for="(column, columnIndex) in $props.matrixSize?.[1] ||
-                      5"
-                      :key="columnIndex"
-                      class="border border-gray-200 text-center"
-                    >
-                      <div
-                        :class="
-                          optionBackgroundClass(
+                    <td v-for="(column, columnIndex) in $props.matrixSize?.[1] ||
+                      5" :key="columnIndex" class="border border-gray-200 text-center">
+                      <div :class="optionBackgroundClass(
+                        convertMatrixMatchOptionToString(
+                          rowIndex,
+                          columnIndex
+                        )
+                      )
+                        ">
+                        <input type="checkbox" :id="`${rowIndex}-${columnIndex}`" :name="`${rowIndex}-${columnIndex}`"
+                          :value="`${columnIndex}`"
+                          class="mx-auto text-primary focus:ring-0 disabled:cursor-not-allowed"
+                          :disabled="isAnswerDisabled" :class="optionBackgroundClass(
                             convertMatrixMatchOptionToString(
                               rowIndex,
                               columnIndex
                             )
                           )
-                        "
-                      >
-                        <input
-                          type="checkbox"
-                          :id="`${rowIndex}-${columnIndex}`"
-                          :name="`${rowIndex}-${columnIndex}`"
-                          :value="`${columnIndex}`"
-                          class="mx-auto text-primary focus:ring-0 disabled:cursor-not-allowed"
-                          :disabled="isAnswerDisabled"
-                          :class="
-                            optionBackgroundClass(
-                              convertMatrixMatchOptionToString(
-                                rowIndex,
-                                columnIndex
-                              )
-                            )
-                          "
-                          style="box-shadow: none"
-                          @click="
+                            " style="box-shadow: none" @click="
                             selectOption(
                               convertMatrixMatchOptionToString(
                                 rowIndex,
                                 columnIndex
                               )
                             )
-                          "
-                          :checked="
-                            isMatrixMatchOptionMarked(
-                              convertMatrixMatchOptionToString(
-                                rowIndex,
-                                columnIndex
-                              )
+                            " :checked="isMatrixMatchOptionMarked(
+                            convertMatrixMatchOptionToString(
+                              rowIndex,
+                              columnIndex
                             )
-                          "
-                          :data-test="`matrixMatchSelector-${rowIndex}-${columnIndex}`"
-                        />
+                          )
+                            " :data-test="`matrixMatchSelector-${rowIndex}-${columnIndex}`" />
                       </div>
                     </td>
                   </tr>
@@ -263,39 +147,28 @@
             </li>
           </ul>
           <!-- answer display -->
-          <div
-            v-if="hasQuizEnded"
-            class="px-2 text-lg mt-2"
-            data-test="matrixMatchCorrectAnswer"
-          >
+          <div v-if="hasQuizEnded" class="px-2 text-lg mt-2" data-test="matrixMatchCorrectAnswer">
             Correct Answer: {{ correctAnswer }}
           </div>
         </div>
       </div>
       <!-- labels -->
-      <div
-        v-if="isQuizAssessment && !hasQuizEnded && !isSessionAnswerRequestProcessing"
-        class="mx-6 md:mx-10 pb-4"
-      >
-      <span v-if="isMarkedForReview" class="bg-violet-500 text-white text-xs font-bold py-0.5 px-2 rounded-full mr-1">MARKED FOR REVIEW</span>
-      <span v-if="isAnswerSubmitted" class="bg-emerald-600 text-white text-xs font-bold py-0.5 px-2 rounded-full mr-1">ANSWERED</span>
-      <span v-if="!isAnswerSubmitted" class="bg-red-500 text-white text-xs font-bold py-0.5 px-2 rounded-full mr-1">NOT ANSWERED</span>
+      <div v-if="isQuizAssessment && !hasQuizEnded && !isSessionAnswerRequestProcessing" class="mx-6 md:mx-10 pb-4">
+        <span v-if="isMarkedForReview"
+          class="bg-violet-500 text-white text-xs font-bold py-0.5 px-2 rounded-full mr-1">MARKED FOR REVIEW</span>
+        <span v-if="isAnswerSubmitted"
+          class="bg-emerald-600 text-white text-xs font-bold py-0.5 px-2 rounded-full mr-1">ANSWERED</span>
+        <span v-if="!isAnswerSubmitted"
+          class="bg-red-500 text-white text-xs font-bold py-0.5 px-2 rounded-full mr-1">NOT ANSWERED</span>
       </div>
       <!-- Solution container -->
-      <div
-        v-if="
-          ((!isQuizAssessment && $props.isAnswerSubmitted) || hasQuizEnded) &&
-          $props.displaySolution &&
-          isSolutionTextPresent
-        "
-        class="mx-6 md:mx-10 py-4"
-      >
+      <div v-if="
+        ((!isQuizAssessment && $props.isAnswerSubmitted) || hasQuizEnded) &&
+        $props.displaySolution &&
+        isSolutionTextPresent
+      " class="mx-6 md:mx-10 py-4">
         <p class="text-lg base:text-lg font-bold">Solution:</p>
-        <p
-          :class="solutionTextClass"
-          data-test="solution-text"
-          v-html="solutionText"
-        ></p>
+        <p :class="solutionTextClass" data-test="solution-text" v-html="solutionText"></p>
       </div>
     </div>
   </div>
@@ -737,9 +610,8 @@ export default defineComponent({
     }
 
     const questionHeaderPrefix = computed(() => {
-      return `Q.${
-        props.currentQuestionIndex + 1
-      } | ${questionTypeHeaderMapping.get(props.questionType)}`;
+      return `Q.${props.currentQuestionIndex + 1
+        } | ${questionTypeHeaderMapping.get(props.questionType)}`;
     });
 
     const questionHeaderSuffix = computed(() => {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -1,95 +1,49 @@
 <template>
   <div class="h-full flex flex-col bg-white w-full justify-between absolute">
-    <Header
-      v-if="isQuizAssessment"
-      :hasQuizEnded="hasQuizEnded"
-      :hasTimeLimit="quizTimeLimit != null"
-      v-model:isPaletteVisible="isPaletteVisible"
-      :timeRemaining="timeRemaining"
+    <Header v-if="isQuizAssessment" :hasQuizEnded="hasQuizEnded" :hasTimeLimit="quizTimeLimit != null"
+      v-model:isPaletteVisible="isPaletteVisible" :timeRemaining="timeRemaining"
       :isSessionAnswerRequestProcessing="$props.isSessionAnswerRequestProcessing"
-      :warningTimeLimit="timeLimitWarningThreshold"
-      :title="title"
-      :userId="userId"
-      :quizType="quizType"
-      @time-limit-warning="displayTimeLimitWarning"
-      @end-test="endTest"
-      @end-test-by-time="endTestByTime"
-      data-test="header"
-    ></Header>
+      :warningTimeLimit="timeLimitWarningThreshold" :title="title" :userId="userId" :quizType="quizType"
+      @time-limit-warning="displayTimeLimitWarning" @end-test="endTest" @end-test-by-time="endTestByTime"
+      data-test="header"></Header>
     <div v-if="!isQuizAssessment">
-      <div
-        class="bg-white-400 w-full justify between">
+      <div class="bg-white-400 w-full justify between">
         <div class="p-4 h-14 bg-white">
           <div class="float-left text-lg sm:text-xl truncate" data-test="test-name">
-          {{ $props.title }}
+            {{ $props.title }}
           </div>
           <div class="float-right text-lg sm:text-xl mx-1 px-1 " data-test="user-id">
-          Id: {{ $props.userId }}
+            Id: {{ $props.userId }}
           </div>
         </div>
       </div>
     </div>
-    <div
-      class="scroll-container flex flex-col grow bg-white w-full justify-between overflow-hidden"
-    >
-      <Body
-        :text="currentQuestion.text"
-        :solutionText="currentQuestion.solution"
-        :class="bodyContainerClass"
-        :options="currentQuestion.options"
-        :correctAnswer="questionCorrectAnswer"
-        :questionType="questionType"
-        :isGradedQuestion="isGradedQuestion"
-        :maxCharLimit="currentQuestion.max_char_limit"
-        :matrixSize="currentQuestion.matrix_size"
-        :isPortrait="isPortrait"
-        :imageData="currentQuestion?.image"
-        :displaySolution="displaySolution"
-        :draftAnswer="draftResponses[currentQuestionIndex]"
-        :submittedAnswer="currentQuestionResponseAnswer"
-        :isAnswerSubmitted="isAnswerSubmitted"
+    <div class="scroll-container flex flex-col grow bg-white w-full justify-between overflow-hidden">
+
+      <Body :text="currentQuestion.text" :solutionText="currentQuestion.solution" :class="bodyContainerClass"
+        :options="currentQuestion.options" :correctAnswer="questionCorrectAnswer" :questionType="questionType"
+        :isGradedQuestion="isGradedQuestion" :maxCharLimit="currentQuestion.max_char_limit"
+        :matrixSize="currentQuestion.matrix_size" :isPortrait="isPortrait" :imageData="currentQuestion?.image"
+        :displaySolution="displaySolution" :draftAnswer="draftResponses[randomIndex[currentQuestionIndex]]"
+        :submittedAnswer="currentQuestionResponseAnswer" :isAnswerSubmitted="isAnswerSubmitted"
         :isMarkedForReview="isMarkedForReview"
-        :isSessionAnswerRequestProcessing="$props.isSessionAnswerRequestProcessing"
-        :isPaletteVisible="isPaletteVisible"
-        :isDraftAnswerCleared="isDraftAnswerCleared"
-        :quizType="quizType"
-        :hasQuizEnded="hasQuizEnded"
-        :optionalLimitReached="optionalLimitReached"
-        :questionSetTitle="questionSetTitle"
-        :currentQuestionIndex="currentQuestionIndex"
-        :questionSetStates="questionSetStates"
-        :title="title"
-        :subject="subject"
-        :testFormat="testFormat"
-        :maxMarks="maxMarks"
-        :maxQuestionsAllowedToAttempt="maxQuestionsAllowedToAttempt"
-        :quizTimeLimit="quizTimeLimit"
-        :numQuestions = "numQuestions"
-        @option-selected="questionOptionSelected"
-        @subjective-answer-entered="subjectiveAnswerUpdated"
-        @numerical-answer-entered="numericalAnswerUpdated"
-        @navigate="navigateToQuestion"
-        :key="reRenderKey"
-        data-test="body"
-        ref="body"
-      ></Body>
-      <Footer
-        :isAnswerSubmitted="isAnswerSubmitted"
-        :isMarkedForReview="isMarkedForReview"
+        :isSessionAnswerRequestProcessing="$props.isSessionAnswerRequestProcessing" :isPaletteVisible="isPaletteVisible"
+        :isDraftAnswerCleared="isDraftAnswerCleared" :quizType="quizType" :hasQuizEnded="hasQuizEnded"
+        :optionalLimitReached="optionalLimitReached" :questionSetTitle="questionSetTitle"
+        :currentQuestionIndex="currentQuestionIndex" :questionSetStates="questionSetStates" :title="title"
+        :subject="subject" :testFormat="testFormat" :maxMarks="maxMarks"
+        :maxQuestionsAllowedToAttempt="maxQuestionsAllowedToAttempt" :quizTimeLimit="quizTimeLimit"
+        :numQuestions="numQuestions" @option-selected="questionOptionSelected"
+        @subjective-answer-entered="subjectiveAnswerUpdated" @numerical-answer-entered="numericalAnswerUpdated"
+        @navigate="navigateToQuestion" :key="reRenderKey" data-test="body" ref="body"></Body>
+      <Footer :isAnswerSubmitted="isAnswerSubmitted" :isMarkedForReview="isMarkedForReview"
         :isPreviousButtonShown="currentQuestionIndex > 0"
-        :isNextButtonShown="currentQuestionIndex != questions.length - 1"
-        :isSubmitEnabled="isAttemptValid"
-        :quizType="quizType"
-        :hasQuizEnded="hasQuizEnded"
+        :isNextButtonShown="currentQuestionIndex != questions.length - 1" :isSubmitEnabled="isAttemptValid"
+        :quizType="quizType" :hasQuizEnded="hasQuizEnded"
         :isSessionAnswerRequestProcessing="$props.isSessionAnswerRequestProcessing"
-        :continueAfterAnswerSubmit="$props.continueAfterAnswerSubmit"
-        @submit="submitQuestion"
-        @continue="showNextQuestion"
-        @previous="showPreviousQuestion"
-        @clear="clearAnswer"
-        @mark-for-review="markForReviewQuestion"
-        data-test="footer"
-      ></Footer>
+        :continueAfterAnswerSubmit="$props.continueAfterAnswerSubmit" @submit="submitQuestion"
+        @continue="showNextQuestion" @previous="showPreviousQuestion" @clear="clearAnswer"
+        @mark-for-review="markForReviewQuestion" data-test="footer"></Footer>
     </div>
   </div>
 </template>
@@ -135,6 +89,10 @@ export default defineComponent({
     questions: {
       required: true,
       type: Array as PropType<Question[]>
+    },
+    randomIndex: {
+      required: true,
+      type: Array as PropType<number[]>
     },
     currentQuestionIndex: {
       type: Number,
@@ -292,7 +250,7 @@ To attempt Q.${props.currentQuestionIndex + 1}, unselect an answer to another qu
     function questionOptionSelected(answer: number | string) {
       if (isQuestionTypeSingleChoice.value && typeof answer == "number") {
         // for MCQ, simply set the option as the current response
-        state.draftResponses[props.currentQuestionIndex] = [answer]
+        state.draftResponses[props.randomIndex[props.currentQuestionIndex]] = [answer]
         return
       }
 
@@ -301,17 +259,17 @@ To attempt Q.${props.currentQuestionIndex + 1}, unselect an answer to another qu
         // answer: CT
         // updated answer -> [AQ, BR, CS, CT]
         // if answer: CS, updated answer -> [AQ, BR]
-        if (state.draftResponses[props.currentQuestionIndex] == null) {
-          state.draftResponses[props.currentQuestionIndex] = []
+        if (state.draftResponses[props.randomIndex[props.currentQuestionIndex]] == null) {
+          state.draftResponses[props.randomIndex[props.currentQuestionIndex]] = []
         }
 
-        let currentResponse = clonedeep(state.draftResponses[props.currentQuestionIndex])
+        let currentResponse = clonedeep(state.draftResponses[props.randomIndex[props.currentQuestionIndex]])
         if (Array.isArray(currentResponse)) {
           const answerPositionInResponse = currentResponse.indexOf(answer)
           if (answerPositionInResponse != -1) {
             currentResponse.splice(answerPositionInResponse, 1)
             if (currentResponse.length == 0) {
-            // if all options unselected, set answer to null
+              // if all options unselected, set answer to null
               currentResponse = null;
             }
           } else {
@@ -319,36 +277,36 @@ To attempt Q.${props.currentQuestionIndex + 1}, unselect an answer to another qu
             currentResponse.sort()
           }
         }
-        state.draftResponses[props.currentQuestionIndex] = currentResponse
+        state.draftResponses[props.randomIndex[props.currentQuestionIndex]] = currentResponse
       }
     }
 
     function submitQuestion() {
       if (!state.localResponses.length) return
-      state.localResponses[props.currentQuestionIndex].answer =
-        state.draftResponses[props.currentQuestionIndex]
-      if (state.draftResponses[props.currentQuestionIndex] != null) {
+      state.localResponses[props.randomIndex[props.currentQuestionIndex]].answer =
+        state.draftResponses[props.randomIndex[props.currentQuestionIndex]]
+      if (state.draftResponses[props.randomIndex[props.currentQuestionIndex]] != null) {
         // question is answered => set review to false
-        state.localResponses[props.currentQuestionIndex].marked_for_review = false;
+        state.localResponses[props.randomIndex[props.currentQuestionIndex]].marked_for_review = false;
       }
       context.emit("submit-question")
     }
 
     function clearAnswer() {
       state.reRenderKey = !state.reRenderKey
-      state.draftResponses[props.currentQuestionIndex] = null
+      state.draftResponses[props.randomIndex[props.currentQuestionIndex]] = null
       state.isDraftAnswerCleared = true
     }
 
     function markForReviewQuestion() {
-      state.previousLocalResponse = clonedeep(state.localResponses[props.currentQuestionIndex]);
-      state.localResponses[props.currentQuestionIndex].marked_for_review = true;
+      state.previousLocalResponse = clonedeep(state.localResponses[props.randomIndex[props.currentQuestionIndex]]);
+      state.localResponses[props.randomIndex[props.currentQuestionIndex]].marked_for_review = true;
       let markForReviewInfoText = `Question ${props.currentQuestionIndex + 1} is marked for review.`
-      if (state.localResponses[props.currentQuestionIndex].answer != null) {
+      if (state.localResponses[props.randomIndex[props.currentQuestionIndex]].answer != null) {
         markForReviewInfoText += `\nAnswer to Question ${props.currentQuestionIndex + 1} is cleared!`
         clearAnswer()
         submitQuestion()
-      } else if (state.draftResponses[props.currentQuestionIndex] != null) {
+      } else if (state.draftResponses[props.randomIndex[props.currentQuestionIndex]] != null) {
         markForReviewInfoText += "\nThis action does not save your answer!"
       }
       state.toast.info(
@@ -400,10 +358,10 @@ To attempt Q.${props.currentQuestionIndex + 1}, unselect an answer to another qu
     function resetState() {
       if (
         (state.isDraftAnswerCleared || isAnswerSubmitted.value) &&
-        state.draftResponses[props.currentQuestionIndex] !=
-          currentQuestionResponseAnswer.value
+        state.draftResponses[props.randomIndex[props.currentQuestionIndex]] !=
+        currentQuestionResponseAnswer.value
       ) {
-        state.draftResponses[props.currentQuestionIndex] =
+        state.draftResponses[props.randomIndex[props.currentQuestionIndex]] =
           currentQuestionResponseAnswer.value
       }
       state.isDraftAnswerCleared = false
@@ -411,12 +369,12 @@ To attempt Q.${props.currentQuestionIndex + 1}, unselect an answer to another qu
     }
 
     function numericalAnswerUpdated(answer: number | null) {
-      state.draftResponses[props.currentQuestionIndex] = answer
+      state.draftResponses[props.randomIndex[props.currentQuestionIndex]] = answer
     }
 
     /** update the attempt to the current question - valid for subjective questions */
     function subjectiveAnswerUpdated(answer: string) {
-      state.draftResponses[props.currentQuestionIndex] = answer
+      state.draftResponses[props.randomIndex[props.currentQuestionIndex]] = answer
     }
 
     function endTest() {
@@ -432,16 +390,16 @@ To attempt Q.${props.currentQuestionIndex + 1}, unselect an answer to another qu
           }
         }
         state.toast.success(
-            `Total Questions: ${props.numQuestions}
+          `Total Questions: ${props.numQuestions}
 Questions Answered: ${attemptedQuestions}
 Questions Marked for Review and Unanswered: ${markedForReviewAndUnansweredQuestions}
 \nUse the Question Palette to review all questions.
 For final submission, click the End Test button again.`,
-            {
-              position: POSITION.TOP_CENTER,
-              timeout: 6000,
-              draggablePercent: 0.4
-            }
+          {
+            position: POSITION.TOP_CENTER,
+            timeout: 6000,
+            draggablePercent: 0.4
+          }
         )
         state.hasEndTestBeenClickedOnce = false;
       } else {
@@ -466,7 +424,7 @@ For final submission, click the End Test button again.`,
     }))
 
     const currentQuestion = computed(
-      () => props.questions[props.currentQuestionIndex]
+      () => props.questions[props.randomIndex[props.currentQuestionIndex]]
     )
 
     const questionType = computed(() => currentQuestion.value.type)
@@ -498,7 +456,7 @@ For final submission, click the End Test button again.`,
     )
 
     const currentQuestionResponse = computed(
-      () => props.responses[props.currentQuestionIndex]
+      () => props.responses[props.randomIndex[props.currentQuestionIndex]]
     )
 
     const currentQuestionResponseAnswer = computed(
@@ -515,7 +473,7 @@ For final submission, click the End Test button again.`,
         return true
       }
       if (isQuestionTypeSingleChoice.value || isQuestionTypeMultiChoice.value) {
-        return currentQuestionResponseAnswer.value != []
+        return currentQuestionResponseAnswer.value != null
       }
       return true
     })
@@ -529,8 +487,8 @@ For final submission, click the End Test button again.`,
         // this cannot be answered
         return false
       }
-      const currentDraftResponse = state.draftResponses[
-        props.currentQuestionIndex
+      const currentDraftResponse = state.draftResponses[props.randomIndex[
+        props.currentQuestionIndex]
       ] as DraftResponse
       if (currentDraftResponse == null) {
         return false
@@ -568,12 +526,12 @@ For final submission, click the End Test button again.`,
     function displayTimeLimitWarning() {
       if (!props.hasQuizEnded) {
         state.toast.warning(
-            `Only ${timeLimitWarningThreshold} minutes left! Please submit!`,
-            {
-              position: POSITION.TOP_CENTER,
-              timeout: 3000,
-              draggablePercent: 0.4
-            }
+          `Only ${timeLimitWarningThreshold} minutes left! Please submit!`,
+          {
+            position: POSITION.TOP_CENTER,
+            timeout: 3000,
+            draggablePercent: 0.4
+          }
         )
         context.emit("test-warning-shown");
       }
@@ -624,10 +582,13 @@ For final submission, click the End Test button again.`,
 <style>
 .truncate {
   @apply whitespace-nowrap overflow-hidden overflow-ellipsis;
-  max-width: 10em; /*(10em) Adjust this value to determine the maximum width in characters */
+  max-width: 10em;
+  /*(10em) Adjust this value to determine the maximum width in characters */
 }
+
 .scroll-container {
-  height: 100vh; /* Adjust the height as per your needs */
+  height: 100vh;
+  /* Adjust the height as per your needs */
   overflow: auto;
 }
 </style>

--- a/src/services/Functional/Utilities.ts
+++ b/src/services/Functional/Utilities.ts
@@ -1,5 +1,11 @@
 import store from "@/store/index";
-import { Question, submittedAnswer, CorrectAnswerType, answerEvaluation, QuestionBucketingMap } from "@/types";
+import {
+  Question,
+  submittedAnswer,
+  CorrectAnswerType,
+  answerEvaluation,
+  QuestionBucketingMap,
+} from "@/types";
 const isEqual = require("deep-eql");
 
 /**
@@ -87,7 +93,8 @@ export function isQuestionAnswerCorrect(
     valid: false,
     answered: false,
   } as answerEvaluation;
-
+  console.log("questionDetail", questionDetail);
+  console.log("userAnswer", userAnswer);
   if (questionDetail.graded) {
     answerEvaluation.valid = true;
 
@@ -103,7 +110,12 @@ export function isQuestionAnswerCorrect(
         const correctAnswer: CorrectAnswerType = questionDetail.correct_answer;
         if (isEqual(userAnswer, correctAnswer)) {
           answerEvaluation.isCorrect = true;
-        } else if (doesPartialMarkingExist && Array.isArray(userAnswer) && Array.isArray(correctAnswer) && userAnswer.length > 0) {
+        } else if (
+          doesPartialMarkingExist &&
+          Array.isArray(userAnswer) &&
+          Array.isArray(correctAnswer) &&
+          userAnswer.length > 0
+        ) {
           // check if user answer is a subset of correct answer
           // ensure userAnswer and correctAnswer are treated as array of numbers here
           const isSubset = (userAnswer as number[]).every((option) =>
@@ -120,7 +132,12 @@ export function isQuestionAnswerCorrect(
         const correctAnswer: CorrectAnswerType = questionDetail.correct_answer;
         if (isEqual(userAnswer, correctAnswer)) {
           answerEvaluation.isCorrect = true;
-        } else if (doesPartialMarkingExist && Array.isArray(userAnswer) && Array.isArray(correctAnswer) && userAnswer.length > 0) {
+        } else if (
+          doesPartialMarkingExist &&
+          Array.isArray(userAnswer) &&
+          Array.isArray(correctAnswer) &&
+          userAnswer.length > 0
+        ) {
           // check if user answer is a subset of correct answer
           const isSubset = (userAnswer as string[]).every((option) =>
             (correctAnswer as string[]).includes(option)
@@ -150,13 +167,15 @@ export function isQuestionAnswerCorrect(
       answerEvaluation.answered = true;
       const correctAnswer: CorrectAnswerType = questionDetail.correct_answer;
 
-      if (questionDetail.type == "numerical-float" &&
-          typeof correctAnswer == "number" &&
-          Math.abs(userAnswer - correctAnswer) < 0.05
+      if (
+        questionDetail.type == "numerical-float" &&
+        typeof correctAnswer == "number" &&
+        Math.abs(userAnswer - correctAnswer) < 0.05
       ) {
         answerEvaluation.isCorrect = true; // tolerance of error = 0.05
-      } else if (questionDetail.type == "numerical-integer" &&
-          userAnswer == correctAnswer
+      } else if (
+        questionDetail.type == "numerical-integer" &&
+        userAnswer == correctAnswer
       ) {
         answerEvaluation.isCorrect = true;
       } else answerEvaluation.isCorrect = false;
@@ -176,14 +195,17 @@ export function isQuestionAnswerCorrect(
  * @returns {boolean} - whether the question details have been fetched or not
  */
 export function isQuestionFetched(qsetIndex: number, questionIndex: number) {
-  const bucketToCheck = Math.floor(questionIndex / store.state.bucketSize)
+  const bucketToCheck = Math.floor(questionIndex / store.state.bucketSize);
   if (
-    'questionBucketingMaps' in store.state &&
+    "questionBucketingMaps" in store.state &&
     store.state.questionBucketingMaps[qsetIndex] != null &&
     store.state.questionBucketingMaps[qsetIndex][bucketToCheck] != null &&
-    'isFetched' in store.state.questionBucketingMaps[qsetIndex][bucketToCheck]
-  ) return store.state.questionBucketingMaps[qsetIndex][bucketToCheck].isFetched
-  return true
+    "isFetched" in store.state.questionBucketingMaps[qsetIndex][bucketToCheck]
+  ) {
+    return store.state.questionBucketingMaps[qsetIndex][bucketToCheck]
+      .isFetched;
+  }
+  return true;
 }
 
 /**
@@ -194,28 +216,36 @@ export function isQuestionFetched(qsetIndex: number, questionIndex: number) {
  * @param {Array<number>} totalQuestionsInEachSet - array of total number of questions in each question set
  */
 export function createQuestionBuckets(totalQuestionsInEachSet: Array<number>) {
-  const questionBucketingMaps = [] as Array<QuestionBucketingMap>
+  // number of questions in each set - 30
+  const questionBucketingMaps = [] as Array<QuestionBucketingMap>;
 
   // calculate total buckets possible
   for (const [mapIndex, totalQuestions] of totalQuestionsInEachSet.entries()) {
-    const totalBucketsPossible = Math.ceil(totalQuestions / store.state.bucketSize)
+    const totalBucketsPossible = Math.ceil(
+      totalQuestions / store.state.bucketSize // 30/10 = 3
+    );
 
     // create the bucket map
-    const questionBucketingMap = {} as QuestionBucketingMap
-    for (let bucketIndex = 0; bucketIndex < totalBucketsPossible; bucketIndex++) {
+    const questionBucketingMap = {} as QuestionBucketingMap;
+    for (
+      let bucketIndex = 0;
+      bucketIndex < totalBucketsPossible;
+      bucketIndex++
+    ) {
       questionBucketingMap[bucketIndex] = {
-        start: (bucketIndex * store.state.bucketSize),
-        end: (
+        start: bucketIndex * store.state.bucketSize,
+        end:
           bucketIndex == totalBucketsPossible - 1 &&
-        totalQuestions % store.state.bucketSize != 0
-        )
-          ? totalQuestions - 1
-          : (bucketIndex * store.state.bucketSize) + (store.state.bucketSize - 1),
+          totalQuestions % store.state.bucketSize != 0
+            ? totalQuestions - 1
+            : bucketIndex * store.state.bucketSize +
+              (store.state.bucketSize - 1),
         isFetched: !bucketIndex,
-      }
+      };
     }
     questionBucketingMaps.push(questionBucketingMap);
+    // console.log("questionBucketingMap", questionBucketingMap);
   }
 
-  store.dispatch("setQuestionBucketMap", questionBucketingMaps)
+  store.dispatch("setQuestionBucketMap", questionBucketingMaps);
 }

--- a/src/services/Functional/Utilities.ts
+++ b/src/services/Functional/Utilities.ts
@@ -93,8 +93,8 @@ export function isQuestionAnswerCorrect(
     valid: false,
     answered: false,
   } as answerEvaluation;
-  console.log("questionDetail", questionDetail);
-  console.log("userAnswer", userAnswer);
+  // console.log("questionDetail", questionDetail);
+  // console.log("userAnswer", userAnswer);
   if (questionDetail.graded) {
     answerEvaluation.valid = true;
 

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -2,128 +2,53 @@
   <div class="h-full">
     <!-- loading spinner -->
     <div v-if="!isQuizLoaded" class="flex justify-center h-full">
-      <BaseIcon
-        name="spinner-solid"
-        iconClass="animate-spin h-10 w-10 object-scale-down my-auto"
-      />
+      <BaseIcon name="spinner-solid" iconClass="animate-spin h-10 w-10 object-scale-down my-auto" />
     </div>
 
     <div v-else class="h-full flex flex-col">
-      <icon-button
-        v-if="shouldShowOmrToggle"
-        :titleConfig="toggleButtonTextConfig"
-        :iconConfig="toggleButtonIconConfig"
-        :buttonClass="toggleButtonIconClass"
-        class="rounded-2xl shadow-lg mt-5 place-self-center"
-        data-test="toggleOmrMode"
-        @click="toggleOmrMode"
-      ></icon-button>
+      <icon-button v-if="shouldShowOmrToggle" :titleConfig="toggleButtonTextConfig" :iconConfig="toggleButtonIconConfig"
+        :buttonClass="toggleButtonIconClass" class="rounded-2xl shadow-lg mt-5 place-self-center"
+        data-test="toggleOmrMode" @click="toggleOmrMode"></icon-button>
 
-      <Splash
-        v-if="isSplashShown"
-        :title="title"
-        :subject="metadata.subject"
-        :grade="metadata.grade"
-        :isFirstSession="isFirstSession"
-        :hasQuizEnded="hasQuizEnded"
-        :reviewAnswers="reviewAnswers"
-        :sessionEndTimeText="sessionEndTimeText"
-        :numQuestions="maxQuestionsAllowedToAttempt"
-        :quizType="computedQuizType"
-        :quizTimeLimit="quizTimeLimit"
-        :maxMarks="maxMarks"
-        :maxQuestionsAllowedToAttempt="numGradedQuestions"
-        :testFormat="metadata.test_format || ''"
-        :displaySolution="displaySolution"
-        :questions="questions"
-        :questionSetStates="questionSetStates"
-        @start="startQuiz"
-        data-test="splash"
-      ></Splash>
+      <Splash v-if="isSplashShown" :title="title" :subject="metadata.subject" :grade="metadata.grade"
+        :isFirstSession="isFirstSession" :hasQuizEnded="hasQuizEnded" :reviewAnswers="reviewAnswers"
+        :sessionEndTimeText="sessionEndTimeText" :numQuestions="maxQuestionsAllowedToAttempt"
+        :quizType="computedQuizType" :quizTimeLimit="quizTimeLimit" :maxMarks="maxMarks"
+        :maxQuestionsAllowedToAttempt="numGradedQuestions" :testFormat="metadata.test_format || ''"
+        :displaySolution="displaySolution" :questions="questions" :questionSetStates="questionSetStates"
+        @start="startQuiz" data-test="splash"></Splash>
 
-      <OmrModal
-        :questions="questions"
-        class="absolute z-10"
-        :class="{
-          hidden: !isOmrMode,
-        }"
-        :quizType="metadata.quiz_type"
-        :hasQuizEnded="hasQuizEnded"
-        :numQuestions="maxQuestionsAllowedToAttempt"
-        :maxQuestionsAllowedToAttempt="currentMaxQuestionsAllowedToAttempt"
-        :questionSetStates="questionSetStates"
-        :qsetIndex="currentQsetIndex"
-        :qsetIndexLimits="currentQsetIndexLimits"
-        :quizTimeLimit="quizTimeLimit"
+      <OmrModal :questions="questions" class="absolute z-10" :class="{
+        hidden: !isOmrMode,
+      }" :quizType="metadata.quiz_type" :hasQuizEnded="hasQuizEnded" :numQuestions="maxQuestionsAllowedToAttempt"
+        :maxQuestionsAllowedToAttempt="currentMaxQuestionsAllowedToAttempt" :questionSetStates="questionSetStates"
+        :qsetIndex="currentQsetIndex" :qsetIndexLimits="currentQsetIndexLimits" :quizTimeLimit="quizTimeLimit"
+        :isSessionAnswerRequestProcessing="isSessionAnswerRequestProcessing" :userId="userId" :title="title"
+        :subject="metadata.subject" :testFormat="metadata.test_format || ''" :timeRemaining="timeRemaining"
+        :maxMarks="maxMarks" v-model:currentQuestionIndex="currentQuestionIndex" v-model:responses="responses"
+        v-model:previousOmrResponses="previousOmrResponses" @submit-omr-question="submitOmrQuestion" @end-test="endTest"
+        data-test="omr-modal" v-if="isQuestionShown && isOmrMode"></OmrModal>
+
+      <QuestionModal :questions="questions" :class="{
+        hidden: isOmrMode,
+      }" :quizType="metadata.quiz_type" :hasQuizEnded="hasQuizEnded" :numQuestions="maxQuestionsAllowedToAttempt"
+        :maxQuestionsAllowedToAttempt="currentMaxQuestionsAllowedToAttempt" :questionSetTitle="currentQsetTitle"
+        :questionSetStates="questionSetStates" :qsetIndexLimits="currentQsetIndexLimits" :quizTimeLimit="quizTimeLimit"
         :isSessionAnswerRequestProcessing="isSessionAnswerRequestProcessing"
-        :userId="userId"
-        :title="title"
-        :subject="metadata.subject"
-        :testFormat="metadata.test_format || ''"
-        :timeRemaining="timeRemaining"
-        :maxMarks="maxMarks"
-        v-model:currentQuestionIndex="currentQuestionIndex"
-        v-model:responses="responses"
-        v-model:previousOmrResponses="previousOmrResponses"
-        @submit-omr-question="submitOmrQuestion"
-        @end-test="endTest"
-        data-test="omr-modal"
-        v-if="isQuestionShown && isOmrMode"
-      ></OmrModal>
+        :continueAfterAnswerSubmit="continueAfterAnswerSubmit" :timeRemaining="timeRemaining" :userId="userId"
+        :title="title" :subject="metadata.subject" :testFormat="metadata.test_format || ''" :maxMarks="maxMarks"
+        v-model:currentQuestionIndex="currentQuestionIndex" v-model:responses="responses"
+        v-model:previousResponse="previousResponse" @submit-question="submitQuestion"
+        @update-review-status="updateQuestionResponse" @end-test="endTest" @fetch-question-bucket="fetchQuestionBucket"
+        v-if="isQuestionShown && !isOmrMode" data-test="modal"></QuestionModal>
 
-      <QuestionModal
-        :questions="questions"
-        :class="{
-          hidden: isOmrMode,
-        }"
-        :quizType="metadata.quiz_type"
-        :hasQuizEnded="hasQuizEnded"
-        :numQuestions="maxQuestionsAllowedToAttempt"
-        :maxQuestionsAllowedToAttempt="currentMaxQuestionsAllowedToAttempt"
-        :questionSetTitle="currentQsetTitle"
-        :questionSetStates="questionSetStates"
-        :qsetIndexLimits="currentQsetIndexLimits"
-        :quizTimeLimit="quizTimeLimit"
-        :isSessionAnswerRequestProcessing="isSessionAnswerRequestProcessing"
-        :continueAfterAnswerSubmit="continueAfterAnswerSubmit"
-        :timeRemaining="timeRemaining"
-        :userId="userId"
-        :title="title"
-        :subject="metadata.subject"
-        :testFormat="metadata.test_format || ''"
-        :maxMarks="maxMarks"
-        v-model:currentQuestionIndex="currentQuestionIndex"
-        v-model:responses="responses"
-        v-model:previousResponse="previousResponse"
-        @submit-question="submitQuestion"
-        @update-review-status="updateQuestionResponse"
-        @end-test="endTest"
-        @fetch-question-bucket="fetchQuestionBucket"
-        v-if="isQuestionShown && !isOmrMode"
-        data-test="modal"
-      ></QuestionModal>
-
-      <Scorecard
-        id="scorecardmodal"
-        class="absolute z-10"
-        :class="{
-          hidden: !isScorecardShown,
-        }"
-        :result="scorecardResult"
-        :showScores="showScores"
-        :quizType="metadata.quiz_type"
-        :metrics="scorecardMetrics"
-        :progressPercentage="scorecardProgress"
-        :qsetMetrics="qsetMetrics"
-        :isShown="isScorecardShown"
-        :title="title"
-        :userId="userId"
-        greeting="Hooray! Congrats on completing the quiz! 🎉"
-        :numQuestionsAnswered="numQuestionsAnswered"
-        :hasGradedQuestions="hasGradedQuestions"
-        @go-back="goToPreviousQuestion"
-        data-test="scorecard"
-      ></Scorecard>
+      <Scorecard id="scorecardmodal" class="absolute z-10" :class="{
+        hidden: !isScorecardShown,
+      }" :result="scorecardResult" :showScores="showScores" :quizType="metadata.quiz_type" :metrics="scorecardMetrics"
+        :progressPercentage="scorecardProgress" :qsetMetrics="qsetMetrics" :isShown="isScorecardShown" :title="title"
+        :userId="userId" greeting="Hooray! Congrats on completing the quiz! 🎉"
+        :numQuestionsAnswered="numQuestionsAnswered" :hasGradedQuestions="hasGradedQuestions"
+        @go-back="goToPreviousQuestion" data-test="scorecard"></Scorecard>
     </div>
   </div>
 </template>
@@ -202,6 +127,7 @@ export default defineComponent({
       title: null as quizTitleType,
       metadata: {} as QuizMetadata,
       questions: [] as Question[],
+      randomIndex: [] as number[],
       responses: [] as SubmittedResponse[], // holds the responses to each item submitted by the viewer
       previousResponse: {} as SubmittedResponse, // holds previous respnose for question being submitted
       previousOmrResponses: [] as SubmittedResponse[],
@@ -363,10 +289,10 @@ export default defineComponent({
             calculateScorecardMetrics();
           }
         } else if (newValue != -1 && !state.hasQuizEnded) {
-          if (!state.responses[newValue].visited) {
+          if (!state.responses[state.randomIndex[newValue]].visited) {
             // if not visited yet
             starttimeSpentOnQuestionCalc(); // for homework and assessment
-            state.responses[newValue].visited = true;
+            state.responses[state.randomIndex[newValue]].visited = true;
             SessionAPIService.updateSessionAnswer(
               state.sessionId,
               state.currentQuestionIndex,
@@ -381,7 +307,7 @@ export default defineComponent({
             }
 
             // for homework, run the timer if question is visited but not submitted
-            if (!isQuizAssessment.value && state.responses[newValue].answer == null) {
+            if (!isQuizAssessment.value && state.responses[state.randomIndex[newValue]].answer == null) {
               starttimeSpentOnQuestionCalc();
             }
           }
@@ -391,7 +317,7 @@ export default defineComponent({
       }
     );
 
-    function getQsetLimits(questionIndex : number) : [number, QuestionSetIndexLimits] {
+    function getQsetLimits(questionIndex: number): [number, QuestionSetIndexLimits] {
       // returns the question set index a question belongs to
       // and the limits of that question set (low and high)
       let qsetIndex = state.qsetCumulativeLengths.findIndex(
@@ -474,7 +400,7 @@ export default defineComponent({
         );
         state.timeRemaining = response.time_remaining;
         if (state.timeRemaining == 0 && isQuizAssessment.value) {
-        // show results based on submitted session's answers (if any)
+          // show results based on submitted session's answers (if any)
           endTest()
         }
         state.currentQuestionIndex = 0;
@@ -486,17 +412,18 @@ export default defineComponent({
     }
 
     async function getQuiz() {
-      const quizDetails : QuizAPIResponse = await QuizAPIService.getQuiz({
+      const quizDetails: QuizAPIResponse = await QuizAPIService.getQuiz({
         quizId: props.quizId,
         omrMode: isOmrMode.value ?? false
       });
+      // console.log("quizDetails---------------------", quizDetails)
       // since we know that there is going to be only one
       // question set for now
       state.questionSets = quizDetails.question_sets;
       const totalQuestionsInEachSet = [];
       for (const [idx, questionSet] of state.questionSets.entries()) {
         state.maxQuestionsAllowedToAttempt += questionSet.max_questions_allowed_to_attempt;
-        state.questions.push(...questionSet.questions) // spread to add questions
+        state.questions.push(...questionSet.questions) // spread to add questions--- aspirin here we are adding the questions to the questions array it is not coplete data
         totalQuestionsInEachSet.push(questionSet.questions.length)
         if (idx == 0) state.qsetCumulativeLengths.push(questionSet.questions.length)
         else state.qsetCumulativeLengths.push(state.qsetCumulativeLengths[idx - 1] + questionSet.questions.length)
@@ -522,6 +449,32 @@ export default defineComponent({
             state.reviewAnswers = false;
           }
         }
+      }
+      // console.log(state.questions);
+      shuffleRandomIndex();
+    }
+    function shuffleRandomIndex() {
+      // Clear the existing randomIndex array
+      state.randomIndex.length = 0;
+      const totalQuestions = state.questions.length;
+      const numBlocks = Math.ceil(totalQuestions / 10);// subsetsize currently set to 10 can extennd it.
+
+      for (let block = 0; block < numBlocks; block++) {
+        // Get the indices for the current block
+        const start = block * 10;
+        const end = Math.min(start + 10, totalQuestions);
+        const blockIndices = Array.from({ length: end - start }, (_, index) => start + index);
+
+        // Shuffle the block indices
+        for (let i = blockIndices.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [blockIndices[i], blockIndices[j]] = [blockIndices[j], blockIndices[i]];
+        }
+
+        // Append shuffled block indices to randomIndex
+        // the issue lies if there are more than 1 question set then this log fails better to shuffle using the question set lengths and add the same logic.
+        state.randomIndex.push(...blockIndices);
+        console.log("randomIndex", state.randomIndex)
       }
     }
 
@@ -558,7 +511,7 @@ export default defineComponent({
     /** updates the session answer once marked for review */
     async function updateQuestionResponse() {
       state.isSessionAnswerRequestProcessing = true;
-      const itemResponse = state.responses[state.currentQuestionIndex];
+      const itemResponse = state.responses[state.randomIndex[state.currentQuestionIndex]];
       const payload: UpdateSessionAnswerAPIPayload = {
         marked_for_review: itemResponse.marked_for_review
       }
@@ -577,7 +530,7 @@ export default defineComponent({
             draggablePercent: 0.4
           }
         )
-        state.responses[state.currentQuestionIndex] = state.previousResponse; // previous value?!
+        state.responses[state.randomIndex[state.currentQuestionIndex]] = state.previousResponse; // previous value?!
       } else {
         // successful response
         state.continueAfterAnswerSubmit = true;
@@ -589,7 +542,7 @@ export default defineComponent({
     async function submitQuestion() {
       state.isSessionAnswerRequestProcessing = true;
       state.continueAfterAnswerSubmit = false;
-      const itemResponse = state.responses[state.currentQuestionIndex];
+      const itemResponse = state.responses[state.randomIndex[state.currentQuestionIndex]];
       const payload: UpdateSessionAnswerAPIPayload = {
         answer: itemResponse.answer,
         marked_for_review: itemResponse.marked_for_review
@@ -614,7 +567,7 @@ export default defineComponent({
             draggablePercent: 0.4
           }
         )
-        state.responses[state.currentQuestionIndex] = state.previousResponse; // previous value?!
+        state.responses[state.randomIndex[state.currentQuestionIndex]] = state.previousResponse; // previous value?!
       } else {
         // successful response
         state.continueAfterAnswerSubmit = true;
@@ -623,7 +576,7 @@ export default defineComponent({
     }
 
     async function submitOmrQuestion(newQuestionIndex: number) {
-      const itemResponse = state.responses[newQuestionIndex];
+      const itemResponse = state.responses[state.randomIndex[newQuestionIndex]];
       const response = await SessionAPIService.updateSessionAnswer( // response.data
         state.sessionId,
         newQuestionIndex,
@@ -642,7 +595,7 @@ export default defineComponent({
             draggablePercent: 0.4
           }
         )
-        state.responses[newQuestionIndex] = state.previousOmrResponses[newQuestionIndex];
+        state.responses[state.randomIndex[newQuestionIndex]] = state.previousOmrResponses[state.randomIndex[newQuestionIndex]];
       }
     }
 
@@ -698,6 +651,7 @@ export default defineComponent({
       } else {
         state.currentQuestionIndex = numQuestions.value;
       }
+      console.log(state.responses)
     }
 
     getQuizCreateSession();
@@ -824,11 +778,11 @@ export default defineComponent({
         const [currentQsetIndex] = getQsetLimits(questionIndex);
         const qsetMetricsObj = state.qsetMetrics[currentQsetIndex];
         if (!questionDetail.graded) qsetMetricsObj.maxQuestionsAllowedToAttempt -= 1
-        if (state.responses[index].marked_for_review === true) {
+        if (state.responses[state.randomIndex[index]].marked_for_review === true) {
           qsetMetricsObj.numQuestionsMarkedForReview += 1;
           state.numMarkedForReview += 1;
         }
-        updateQuestionMetrics(questionDetail, state.responses[index].answer, qsetMetricsObj);
+        updateQuestionMetrics(questionDetail, state.responses[state.randomIndex[index]].answer, qsetMetricsObj);
         if (qsetMetricsObj.numAnswered != 0) qsetMetricsObj.accuracyRate = (qsetMetricsObj.correctlyAnswered + 0.5 * qsetMetricsObj.partiallyAnswered) / qsetMetricsObj.numAnswered;
         state.qsetMetrics[currentQsetIndex].attemptRate = qsetMetricsObj.numAnswered / qsetMetricsObj.maxQuestionsAllowedToAttempt;
         state.qsetMetrics[currentQsetIndex] = qsetMetricsObj;
@@ -939,7 +893,7 @@ export default defineComponent({
           if (state.hasQuizEnded) {
             const questionAnswerEvaluation = isQuestionAnswerCorrect(
               state.questions[qindex],
-              state.responses[qindex].answer,
+              state.responses[state.randomIndex[qindex]].answer,
               state.questions[qindex].marking_scheme?.partial != null // doesPartialMarkingExist
             )
             if (!questionAnswerEvaluation.valid && state.questions[qindex].graded) continue
@@ -948,7 +902,7 @@ export default defineComponent({
               qstate = "neutral"
             } else if (
               !questionAnswerEvaluation.answered ||
-          questionAnswerEvaluation.isCorrect == null
+              questionAnswerEvaluation.isCorrect == null
             ) {
               qstate = "neutral"
             } else {
@@ -960,11 +914,11 @@ export default defineComponent({
             }
           } else {
             if (state.responses.length > 0) {
-              if (!state.responses[qindex].visited) { // initially responses empty
+              if (!state.responses[state.randomIndex[qindex]].visited) { // initially responses empty
                 qstate = "neutral"
               } else {
-                if (state.responses[qindex].answer != null) qstate = "success"
-                else if (state.responses[qindex].marked_for_review) qstate = "review"
+                if (state.responses[state.randomIndex[qindex]].answer != null) qstate = "success"
+                else if (state.responses[state.randomIndex[qindex]].marked_for_review) qstate = "review"
                 else qstate = "error"
               }
             } else qstate = "error"
@@ -1014,6 +968,7 @@ export default defineComponent({
           let globalQuestionIndex = i
           if (qsetIndex != 0) globalQuestionIndex = i + state.qsetCumulativeLengths[qsetIndex - 1]
           state.questions[globalQuestionIndex] = fetchedQuestions[i - bucketStartIndex]
+          // console.log("fetchedQuestions[i - bucketStartIndex]---------------------", fetchedQuestions[i - bucketStartIndex])
         }
 
         store.dispatch("updateBucketFetchedStatus", {


### PR DESCRIPTION
This PR introduces randomized question subset mapping and tweaks the index management for saving responses. The changes improve quiz flexibility and ensure responses are stored correctly under shuffled conditions.

- [X] Implement random question mapping per subset (unidirectional for now) .
- [ ] Implemented random question mapping per subset (Bidirectional) 
- [X] Adjusted index management for saving responses
- [X] Tested with 30-question quiz for proper response storage
- [ ] Extend random subset mapping to work with multiple question sets
- [ ] Implement shuffled question display during quiz
- [ ] Preserve shuffle ordering for index mapping to maintain consistency across sessions