### PR TITLE
fix: progress bar overflow when percentage > 100 (#43)

### DIFF
--- a/src/components/Scorecard.vue
+++ b/src/components/Scorecard.vue
@@ -395,7 +395,10 @@ export default defineComponent({
       (newValue) => {
         if (newValue) {
           setTimeout(() => {
-            state.localProgressBarPercent = props.progressPercentage;
+            state.localProgressBarPercent = Math.min(
+            Math.max(props.progressPercentage, 0),
+                100
+              );
           }, PROGRESS_BAR_ANIMATION_DELAY_TIME);
           // throw some confetti in there
           throwConfetti(state.confettiHandler);


### PR DESCRIPTION
Fixes #43
## Summary
Fixes the progress bar overflow issue when percentage exceeds hundred(100).
Previously, the progress value was not bounded, causing UI overflow.
Now the value is clamped between 0 and 100 using Math.min and Math.max.
## Test Plan
- Tested locally
- Verified progress bar does not overflow when percentage > 100
- UI behaves correctly for edge cases (0, 100, >100)