### PR TITLE
Harden active quiz flow by removing hidden-answer local evaluation

### DIFF
--- a/src/services/Functional/Utilities.ts
+++ b/src/services/Functional/Utilities.ts
@@ -90,6 +90,24 @@ export function isQuestionAnswerCorrect(
 
   if (questionDetail.graded) {
     answerEvaluation.valid = true;
+    const hasAnswerKey = questionDetail.correct_answer != null;
+    const requiresAnswerKey = (
+      questionDetail.type == "single-choice" ||
+      questionDetail.type == "multi-choice" ||
+      questionDetail.type == "matrix-match" ||
+      questionDetail.type == "matrix-rating" ||
+      questionDetail.type == "matrix-numerical" ||
+      questionDetail.type == "numerical-integer" ||
+      questionDetail.type == "numerical-float"
+    );
+
+    // Active quiz payloads can intentionally hide answer keys.
+    // In that case, skip correctness evaluation for answer-key based question types.
+    if (requiresAnswerKey && !hasAnswerKey) {
+      answerEvaluation.valid = false;
+      answerEvaluation.answered = userAnswer != null;
+      return answerEvaluation;
+    }
 
     // Handle invalid format: if a number is submitted for single-choice/multi-choice, mark as wrong
     if (typeof userAnswer == "number" && (questionDetail.type == "single-choice" || questionDetail.type == "multi-choice" || questionDetail.type == "matrix-match")) {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -653,7 +653,21 @@ export default defineComponent({
       state.qsetCumulativeLengths = [];
       state.maxQuestionsAllowedToAttempt = 0;
 
-      state.questionSets = quizDetails.question_sets;
+      const shouldHideAnswerKeys = !state.quizLoadedWithAnswers;
+      const sanitizedQuestionSets = quizDetails.question_sets.map((questionSet) => ({
+        ...questionSet,
+        questions: questionSet.questions.map((question) => (
+          shouldHideAnswerKeys
+            ? {
+              ...question,
+              correct_answer: null,
+              solution: null,
+            }
+            : question
+        )),
+      }));
+
+      state.questionSets = sanitizedQuestionSets;
       const totalQuestionsInEachSet = [];
       for (const [idx, questionSet] of state.questionSets.entries()) {
         state.maxQuestionsAllowedToAttempt += questionSet.max_questions_allowed_to_attempt;
@@ -1170,6 +1184,19 @@ export default defineComponent({
           let dynamicIndex = qindex;
           if (!isOmrMode.value) dynamicIndex = state.questionOrder[qindex];
           if (state.hasQuizEnded) {
+            if (
+              state.questions[dynamicIndex].graded &&
+              state.questions[dynamicIndex].correct_answer == null
+            ) {
+              // Answers may be hidden when review payload fetch fails.
+              // Avoid inferring correctness locally without answer keys.
+              qstate = "neutral";
+              states.push({
+                index: qindex,
+                value: qstate
+              })
+              continue;
+            }
             const questionAnswerEvaluation = isQuestionAnswerCorrect(
               state.questions[dynamicIndex],
               state.responses[dynamicIndex].answer,

--- a/tests/unit/services/Functional/Utilities.spec.ts
+++ b/tests/unit/services/Functional/Utilities.spec.ts
@@ -1,0 +1,50 @@
+import { isQuestionAnswerCorrect } from "@/services/Functional/Utilities";
+import { Question, questionType } from "@/types";
+
+const createQuestion = (overrides: Partial<Question>): Question => ({
+  _id: "q-1",
+  type: questionType.SINGLE_CHOICE,
+  text: "Question",
+  options: [{ text: "A", image: null }],
+  correct_answer: [0],
+  image: null,
+  max_char_limit: null,
+  matrix_size: null,
+  matrix_rows: null,
+  graded: true,
+  instructions: null,
+  marking_scheme: null,
+  solution: null,
+  metadata: null,
+  question_set_id: "set-1",
+  source_id: null,
+  ...overrides,
+});
+
+describe("isQuestionAnswerCorrect", () => {
+  it("returns invalid evaluation when answer key is hidden for graded objective question", () => {
+    const question = createQuestion({
+      type: questionType.SINGLE_CHOICE,
+      correct_answer: null,
+    });
+
+    const evaluation = isQuestionAnswerCorrect(question, [0], false);
+
+    expect(evaluation.valid).toBe(false);
+    expect(evaluation.answered).toBe(true);
+    expect(evaluation.isCorrect).toBeUndefined();
+  });
+
+  it("still evaluates graded subjective responses when answer key is hidden", () => {
+    const question = createQuestion({
+      type: questionType.SUBJECTIVE,
+      correct_answer: null,
+    });
+
+    const evaluation = isQuestionAnswerCorrect(question, "my response", false);
+
+    expect(evaluation.valid).toBe(true);
+    expect(evaluation.answered).toBe(true);
+    expect(evaluation.isCorrect).toBe(true);
+  });
+});


### PR DESCRIPTION
Avoid local correctness evaluation when answer keys are intentionally hidden, sanitize active payloads to strip answer keys, and add unit tests for hidden-answer behavior.

Fixes #201

## Summary

This PR hardens active-attempt behavior for quiz sessions where answers are intentionally hidden from the frontend.

### What changed
- Added safeguards in correctness evaluation to **skip local grading** for answer-key dependent question types when `correct_answer` is absent.
- Sanitized active quiz payload handling to strip `correct_answer`/`solution` during non-review flows.
- Prevented incorrect palette/result inference when quiz is ended but answer-bearing review payload is unavailable.
- Added unit tests to verify hidden-answer behavior:
  - objective graded question without answer key => invalid local correctness evaluation
  - subjective graded question behavior remains valid

### Why
The frontend should not infer correctness when answer keys are intentionally withheld. This reduces answer-exposure risk and aligns active attempt behavior with a backend-driven validation model.

## Test Plan

- [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately
  - [x] Added relevant details like Labels/Projects/Milestones etc.
  - [x] No new package added
- [x] Testing
  - [x] Wrote tests
  - [x] Tested locally
  - [ ] Tested on staging
  - [ ] Tested on an actual physical phone
  - [ ] Tested on production

### Commands run
```bash
npm run test:unit -- tests/unit/services/Functional/Utilities.spec.ts