### PR TITLE
feat: Display section names in hamburger menu and on question screen

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -5,6 +5,8 @@
   >
     <div class="overflow-y-auto flex flex-col w-full">
       <div class="bg-gray-300">
+        <!-- section name above question -->
+        <p v-if="questionSetTitle" class="text-xs font-bold uppercase tracking-widest text-primary px-4 pt-2" data-test="section-name">{{ questionSetTitle }} · Q.{{ currentQuestionIndex + 1 }}</p>
         <!-- questionHeaderPrefix shows the question index no. and the type of question -->
         <p
           :class="questionHeaderPrefixClass"

--- a/src/components/Questions/Palette/QuestionPalette.vue
+++ b/src/components/Questions/Palette/QuestionPalette.vue
@@ -61,7 +61,7 @@
 
       <div
         v-for="(questionSetState, index) in questionSetStates" :key="index" class="space-y-2">
-          <p :class="titleTextClass" :data-test="`paletteTitle-${index}`">{{ questionSetState.title }}</p>
+          <p v-if="questionSetState.title" class="text-sm font-bold uppercase tracking-widest text-primary border-l-4 border-primary pl-2 mt-6" :data-test="`paletteTitle-${index}`">{{ questionSetState.title }}</p>
           <div :class="instructionTextClass" :data-test="`paletteInstruction-${index}`" v-html="questionSetState.instructionText"></div>
           <div class="grid grid-cols-5 bp-500:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8 mt-4 space-y-4">
             <PaletteItem


### PR DESCRIPTION
Summary
Displays section names (e.g. Physics, Chemistry) in the hamburger menu and on the question screen for multi-section quizzes.

Changes
QuestionPalette.vue — Section titles now appear as styled headers (bold, uppercase, primary left-border accent) above each group of palette items in the hamburger menu.

Body.vue — A section label is shown above the question header in the format PHYSICS · Q.3 so the user always knows which section they're currently in.

Behaviour
Only renders when a section title exists — no visual change for single-set quizzes with no title.
Uses existing prop flow, no new props or components introduced.

Fixes: #69

Testing
All 54 unit tests pass.