### PR TITLE
quick fix to mathjax loading issue

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="mathJaxRoot"
     class="flex h-full overflow-y-auto"
     :class="{ 'bg-gray-50': isPaletteVisible }"
   >
@@ -544,8 +545,10 @@ import {
   PropType,
   onMounted,
   onUpdated,
+  ref,
 } from "vue";
 import BaseIcon from "../UI/Icons/BaseIcon.vue";
+import { queueMathJaxTypeset } from "@/services/Functional/MathJax";
 import {
   quizType,
   questionSetPalette,
@@ -711,6 +714,7 @@ export default defineComponent({
     },
   },
   setup(props, context) {
+    const mathJaxRoot = ref<HTMLElement | null>(null);
     const isQuizAssessment = computed(() => props.quizType == "assessment");
     const isFormQuiz = computed(() => props.quizType == "form");
     const state = reactive({
@@ -1371,19 +1375,16 @@ export default defineComponent({
     if (isQuestionImagePresent.value) startImageLoading();
 
     onMounted(() => {
-      // Force render any math on the page when component is mounted
-      // @ts-ignore
-      if ("MathJax" in window) (window.MathJax as any).typeset();
+      queueMathJaxTypeset(mathJaxRoot.value);
     });
 
     onUpdated(() => {
-      // Force render any math on the page when component is updated
-      // @ts-ignore
-      if ("MathJax" in window) (window.MathJax as any).typeset();
+      queueMathJaxTypeset(mathJaxRoot.value);
     });
 
     return {
       ...toRefs(state),
+      mathJaxRoot,
       questionHeaderPrefix,
       questionHeaderSuffix,
       stopImageLoading,

--- a/src/components/SinglePage/SinglePageItem.vue
+++ b/src/components/SinglePage/SinglePageItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-full">
+  <div ref="mathJaxRoot" class="flex h-full">
     <!-- Full text mode layout -->
     <div v-if="showFullText" class="flex flex-col w-full max-w-4xl mx-auto p-6 my-4 bg-white shadow-sm" :class="{ 'border-b': true, 'md:border md:rounded-lg': true }">
       <!-- Question header with number and text -->
@@ -857,10 +857,12 @@ import {
   PropType,
   onMounted,
   onUpdated,
+  ref,
 } from "vue";
 
 import { quizType, questionType, DraftResponse } from "@/types"
 import { lazyLoadImages } from "@/directives/lazyLoadImages";
+import { queueMathJaxTypeset } from "@/services/Functional/MathJax";
 
 const MAX_LENGTH_NUMERICAL_CHARACTERS: number = 10; // max length of characters in numerical answer textbox
 
@@ -965,6 +967,7 @@ export default defineComponent({
     },
   },
   setup(props, context) {
+    const mathJaxRoot = ref<HTMLElement | null>(null);
     const isQuizAssessment = computed(
       () => props.quizType == "assessment" || props.quizType == "omr-assessment"
     );
@@ -1667,19 +1670,16 @@ export default defineComponent({
     );
 
     onMounted(() => {
-      // Force render any math on the page when component is mounted
-      // @ts-ignore
-      if ("MathJax" in window) (window.MathJax as any).typeset();
+      queueMathJaxTypeset(mathJaxRoot.value);
     });
 
     onUpdated(() => {
-      // Force render any math on the page when component is updated
-      // @ts-ignore
-      if ("MathJax" in window) (window.MathJax as any).typeset();
+      queueMathJaxTypeset(mathJaxRoot.value);
     });
 
     return {
       ...toRefs(state),
+      mathJaxRoot,
       questionHeaderText,
       optionBackgroundClass,
       isOptionMarked,

--- a/src/services/Functional/MathJax.ts
+++ b/src/services/Functional/MathJax.ts
@@ -1,0 +1,42 @@
+import { nextTick } from "vue";
+
+type MathJaxWindow = Window & {
+  MathJax?: {
+    startup?: {
+      promise?: Promise<unknown>;
+    };
+    typesetClear?: (elements?: HTMLElement[]) => void;
+    typesetPromise?: (elements?: HTMLElement[]) => Promise<void>;
+  };
+};
+
+let typesetQueue: Promise<void> = Promise.resolve();
+
+export function queueMathJaxTypeset(element?: HTMLElement | null) {
+  if (!element) return typesetQueue;
+
+  typesetQueue = typesetQueue
+    .then(async () => {
+      await nextTick();
+
+      const mathJax = (window as MathJaxWindow).MathJax;
+      if (!mathJax?.typesetPromise || !element.isConnected) return;
+
+      if (mathJax.startup?.promise) {
+        await mathJax.startup.promise;
+      }
+
+      if (!element.isConnected) return;
+
+      if (typeof mathJax.typesetClear === "function") {
+        mathJax.typesetClear([element]);
+      }
+
+      await mathJax.typesetPromise([element]);
+    })
+    .catch((error) => {
+      console.error("MathJax typeset failed", error);
+    });
+
+  return typesetQueue;
+}

--- a/tests/e2e/specs/renders-form-with-matrix-questions.js
+++ b/tests/e2e/specs/renders-form-with-matrix-questions.js
@@ -26,7 +26,7 @@ const FORM_METRICS = {
 };
 
 describe("Form with Matrix Questions Tests", () => {
-  let sessionMetrics = FORM_METRICS;
+  const sessionMetrics = FORM_METRICS;
 
   beforeEach(() => {
     cy.on("uncaught:exception", (err) => {

--- a/tests/e2e/specs/renders-player-to-check-timed.js
+++ b/tests/e2e/specs/renders-player-to-check-timed.js
@@ -41,7 +41,7 @@ const timedMetrics = {
 };
 
 describe("Player for Assessment Timed quizzes", () => {
-  let sessionMetrics = timedMetrics;
+  const sessionMetrics = timedMetrics;
 
   beforeEach(() => {
     // stub the response to /quiz/{quizId}
@@ -324,7 +324,7 @@ describe("Player for Homework Quizzes", () => {
       cy.intercept("PATCH", "/session_answers/**", { status: 200 });
       cy.intercept("PATCH", "/sessions/*", (req) => {
         if (req.body && req.body.event === "end-quiz") {
-          req.reply({ body: { time_remaining: 200, metrics: sessionMetrics } });
+          req.reply({ body: { time_remaining: 200, metrics: timedMetrics } });
         } else {
           req.reply({ body: { time_remaining: 200 } });
         }

--- a/tests/e2e/specs/renders-single-page-mode.js
+++ b/tests/e2e/specs/renders-single-page-mode.js
@@ -39,7 +39,7 @@ const SINGLE_PAGE_METRICS = {
 };
 
 describe("Player for Single Page Mode with Full Text", () => {
-  let sessionMetrics = SINGLE_PAGE_METRICS;
+  const sessionMetrics = SINGLE_PAGE_METRICS;
 
   beforeEach(() => {
     // stub the response to /quiz/{quizId}


### PR DESCRIPTION
## Summary
- Replace direct global MathJax `typeset()` calls with a shared queued `typesetPromise()` helper.
- Scope MathJax rendering to the current quiz question component root instead of re-typesetting the whole page.
- Apply the same MathJax handling in normal question view and single-page mode.
- Clean up a few Cypress fixture metric variables from `let` to `const`, and fix the homework test metric reference so lint passes.

## Why
Some quiz questions contain LaTeX inside dynamically-rendered HTML. Calling `MathJax.typeset()` directly on every mount/update can overlap when questions rerender quickly, and it also asks MathJax to scan more of the page than needed. The new helper serializes MathJax work, waits for Vue DOM updates and MathJax startup, skips disconnected elements, clears previous MathJax state for that component, and then typesets only that component.

This should make math rendering more reliable when navigating between questions or viewing single-page quizzes.

## Testing
- Ran `npm run lint` successfully.

## Notes
This PR improves MathJax rendering behavior. It does not change quiz data such as matrix-match `matrix_size` values.