### PR TITLE
docs: remove stale dual-backend references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,6 @@ npm run lint:fix                 # Fix linting issues
 
 Copy `.env.example` to `.env.local` and configure:
 - `VUE_APP_BACKEND`: Backend API URL (default: http://127.0.0.1:8001)
-- `VUE_APP_BACKEND_ECS`: Optional ECS backend URL (used when `?new_backend` query param is present)
 
 For staging/production builds, use `.env.staging` or `.env.production` respectively.
 
@@ -62,7 +61,7 @@ For staging/production builds, use `.env.staging` or `.env.production` respectiv
 
 #### Service Layer
 - `src/services/API/` - API clients and endpoints
-  - `RootClient.ts` - Axios client factory (default Lambda + optional ECS backend)
+  - `RootClient.ts` - Axios client factory
   - `Endpoints.ts` - API endpoint constants
   - `Quiz.ts`, `Question.ts`, `Session.ts`, `Organization.ts`, `Form.ts` - Domain-specific API clients
   - `ErrorHandling.ts` - Global error handler (404 redirect)
@@ -93,7 +92,7 @@ For staging/production builds, use `.env.staging` or `.env.production` respectiv
 ### Authentication & Routing
 - Routes require `userId` and `apiKey` query parameters
 - Main routes: `/quiz/:quizId` and `/form/:quizId` with authentication checks
-- Optional query params: `omrMode`, `singlePageMode`, `autoStart`, `new_backend`
+- Optional query params: `omrMode`, `singlePageMode`, `autoStart`
 - Error handling for 404, 403, quiz-not-available, form-not-available
 
 ### Styling Notes

--- a/context_for_ai/project-context.md
+++ b/context_for_ai/project-context.md
@@ -37,7 +37,6 @@ This is the **Quiz Frontend** for [Avanti Fellows](https://avantifellows.org/), 
 | `omrMode` | Optional. `true` to display in OMR/bubble-sheet mode. |
 | `singlePageMode` | Optional. `true` to show all questions on one page with full text. |
 | `autoStart` | Optional. `true` to skip the splash screen and start immediately. |
-| `new_backend` | Optional. When present (any value), routes API calls to the ECS backend instead of the default Lambda backend. Requires `VUE_APP_BACKEND_ECS` env var to be set. |
 
 ---
 
@@ -121,7 +120,7 @@ quiz-frontend/
 │   │   └── index.ts            # Vuex store (spinner, bucketing, locale)
 │   ├── services/
 │   │   ├── API/
-│   │   │   ├── RootClient.ts   # Axios client factory (default + ECS backend)
+│   │   │   ├── RootClient.ts   # Axios client factory
 │   │   │   ├── Endpoints.ts    # API endpoint constants
 │   │   │   ├── Quiz.ts         # Quiz API (getQuiz)
 │   │   │   ├── Form.ts         # Form API (getForm)
@@ -230,14 +229,9 @@ timeSpentOnQuestion: TimeSpentEntry[]  // per-question time tracking
 qsetMetrics: QuestionSetMetric[] // per-question-set scoring metrics
 ```
 
-### `src/services/API/RootClient.ts` - Dual Backend Support
+### `src/services/API/RootClient.ts` - API Client
+Creates a single Axios instance for the backend (`VUE_APP_BACKEND`). All API services import and use this client.
 
-Creates two Axios instances: one for the default backend (Lambda, `VUE_APP_BACKEND`) and one for the ECS backend (`VUE_APP_BACKEND_ECS`). The `apiClient()` function checks for `?new_backend` in the URL to decide which client to use. This allows A/B testing between backend implementations.
-
-```typescript
-export function apiClient(): AxiosInstance {
-  return useEcsBackend() ? ecsClient! : defaultClient;
-}
 ```
 
 ### `src/services/Functional/Utilities.ts` - Answer Evaluation
@@ -382,7 +376,6 @@ npm run serve
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `VUE_APP_BACKEND` | Default backend API URL | `http://127.0.0.1:8001` |
-| `VUE_APP_BACKEND_ECS` | Optional ECS backend URL. When set, `?new_backend=true` query param routes calls here | (empty) |
 
 ### Common Commands
 


### PR DESCRIPTION
Closes #211

## Summary
Removed stale dual-backend references from docs that were introduced during the Lambda-to-ECS migration (`feature/ecs-backend-switcher` branch) but never merged to main.

Changes:
- `CLAUDE.md`: Removed `VUE_APP_BACKEND_ECS` env var, `new_backend` query param, dual-client description in RootClient section
- `context_for_ai/project-context.md`: Removed `useEcsBackend()`, `ecsClient`, dual-backend code block and section header

## Test Plan
  - [x] Hygiene and Housekeeping
  - [x] Self-review
  - [x] Comments have been added appropriately