### PR TITLE
Feat/remove client side answer dependency

### DIFF
--- a/TODO_hide_answers.md
+++ b/TODO_hide_answers.md
@@ -45,10 +45,10 @@ Students can access correct answers via browser developer tools through multiple
 ## Frontend Changes (Required)
 
 ### 1. Update Type Definitions (`src/types.ts`)
-- [ ] **NEW**: Create `SecureQuestion` interface without `correct_answer` field
+- [x] **MODIFY**: Make `correct_answer` optional on `Question` interface (backend omits it during active attempts)
+- [x] **MODIFY**: Make `solution` optional on `Question` interface
 - [ ] **NEW**: Create `QuestionValidationResponse` interface
-- [ ] **MODIFY**: Update `QuizAPIResponse` to use `SecureQuestion[]` during active quiz
-- [ ] **NEW**: Create `CompletedQuestion` interface with answers (for review mode)
+- [ ] **MODIFY**: Update `QuizAPIResponse` to use secure question type during active quiz
 
 ### 2. API Service Updates
 
@@ -64,16 +64,21 @@ Students can access correct answers via browser developer tools through multiple
 ### 3. Component Updates
 
 #### `src/views/Player.vue`
-- [ ] **MODIFY**: Replace client-side answer evaluation with server validation
+- [x] **MODIFY**: questionSetStates palette degrades to 'neutral' when correct_answer is missing
 - [ ] **NEW**: Add `validateAnswer()` method for homework mode
 - [ ] **MODIFY**: State management to handle validation responses
-- [ ] **MODIFY**: Only load complete question data when quiz is completed
+- [x] **MODIFY**: fetchQuestionBucket preserves homework-revealed answers
 
 #### `src/components/Questions/Body.vue`
-- [ ] **MODIFY**: `optionBackgroundClass()` to use validation results instead of `correct_answer`
-- [ ] **NEW**: Add loading states for answer validation
-- [ ] **MODIFY**: Remove direct access to `correct_answer` prop
+- [x] **MODIFY**: `optionBackgroundClass()` already guards against null correctAnswer
+- [x] **MODIFY**: `numericalAnswerBoxStyling` skips green/red when correctAnswer is null
+- [x] **MODIFY**: Answer display sections gated on `correctAnswer != null`
 - [ ] **NEW**: Handle validation response for styling
+
+#### `src/components/SinglePage/SinglePageItem.vue`
+- [x] **MODIFY**: `optionBackgroundClass()` now guards against null correctAnswer
+- [x] **MODIFY**: `numericalAnswerBoxStyling` skips green/red when correctAnswer is null
+- [x] **MODIFY**: Answer display sections gated on `correctAnswer != null`
 
 #### `src/components/Questions/QuestionModal.vue`
 - [ ] **MODIFY**: Submit flow to call validation API for homework mode
@@ -83,7 +88,7 @@ Students can access correct answers via browser developer tools through multiple
 ### 4. Utility Function Updates
 
 #### `src/services/Functional/Utilities.ts`
-- [ ] **REMOVE**: `isQuestionAnswerCorrect()` function (move to backend)
+- [x] **MODIFY**: `isQuestionAnswerCorrect()` returns invalid eval when correct_answer is missing
 - [ ] **NEW**: `processValidationResponse()` for handling server responses
 - [ ] **NEW**: `formatValidationFeedback()` for UI display
 

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -122,7 +122,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="subjectiveCorrectAnswer"
           >
@@ -150,7 +150,7 @@
           ></Textarea>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="numericalCorrectAnswer"
           >
@@ -248,7 +248,7 @@
           </ul>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixMatchCorrectAnswer"
           >
@@ -342,7 +342,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixRatingCorrectAnswer"
           >
@@ -427,7 +427,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixNumericalCorrectAnswer"
           >
@@ -1265,36 +1265,42 @@ export default defineComponent({
       "bp-420:h-16 sm:h-20 md:h-24 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
     ]);
 
-    const numericalAnswerBoxStyling = computed(() => [
-      {
-        "text-green-500 border-green-500":
-          ((props.submittedAnswer == props.correctAnswer &&
-            isQuestionTypeNumericalInteger.value) ||
-            (typeof props.submittedAnswer == "number" &&
-              typeof props.correctAnswer == "number" &&
-              Math.abs(props.submittedAnswer - props.correctAnswer) < 0.05 &&
-              isQuestionTypeNumericalFloat.value)) &&
-          props.isAnswerSubmitted &&
-          props.isGradedQuestion &&
-          (!isQuizAssessment.value ||
-            (isQuizAssessment.value && props.hasQuizEnded)),
-        "text-red-500 border-red-400":
-          ((props.submittedAnswer != props.correctAnswer &&
-            isQuestionTypeNumericalInteger.value) ||
-            (typeof props.submittedAnswer == "number" &&
-              typeof props.correctAnswer == "number" &&
-              Math.abs(props.submittedAnswer - props.correctAnswer) >= 0.05 &&
-              isQuestionTypeNumericalFloat.value)) &&
-          props.isAnswerSubmitted &&
-          props.isGradedQuestion &&
-          (!isQuizAssessment.value ||
-            (isQuizAssessment.value && props.hasQuizEnded)),
-        "bg-gray-100":
-          (props.isAnswerSubmitted && !props.isGradedQuestion) ||
-          (isQuizAssessment.value && !props.hasQuizEnded),
-      },
-      "h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
-    ]);
+    const numericalAnswerBoxStyling = computed(() => {
+      // skip correctness styling when correct_answer isn't available
+      const hasAnswer = props.correctAnswer !== undefined && props.correctAnswer !== null;
+      return [
+        {
+          "text-green-500 border-green-500":
+            hasAnswer &&
+            ((props.submittedAnswer == props.correctAnswer &&
+              isQuestionTypeNumericalInteger.value) ||
+              (typeof props.submittedAnswer == "number" &&
+                typeof props.correctAnswer == "number" &&
+                Math.abs(props.submittedAnswer - props.correctAnswer) < 0.05 &&
+                isQuestionTypeNumericalFloat.value)) &&
+            props.isAnswerSubmitted &&
+            props.isGradedQuestion &&
+            (!isQuizAssessment.value ||
+              (isQuizAssessment.value && props.hasQuizEnded)),
+          "text-red-500 border-red-400":
+            hasAnswer &&
+            ((props.submittedAnswer != props.correctAnswer &&
+              isQuestionTypeNumericalInteger.value) ||
+              (typeof props.submittedAnswer == "number" &&
+                typeof props.correctAnswer == "number" &&
+                Math.abs(props.submittedAnswer - props.correctAnswer) >= 0.05 &&
+                isQuestionTypeNumericalFloat.value)) &&
+            props.isAnswerSubmitted &&
+            props.isGradedQuestion &&
+            (!isQuizAssessment.value ||
+              (isQuizAssessment.value && props.hasQuizEnded)),
+          "bg-gray-100":
+            (props.isAnswerSubmitted && !props.isGradedQuestion) ||
+            (isQuizAssessment.value && !props.hasQuizEnded),
+        },
+        "h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
+      ];
+    });
 
     state.subjectiveAnswer = defaultSubjectiveAnswer.value;
     state.numericalAnswer = defaultNumericalAnswer.value;

--- a/src/components/SinglePage/SinglePageItem.vue
+++ b/src/components/SinglePage/SinglePageItem.vue
@@ -88,7 +88,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-1 text-lg mt-2"
             data-test="subjectiveCorrectAnswer"
           >
@@ -114,9 +114,8 @@
             @beforeinput="preventKeypressIfApplicable"
             data-test="numericalAnswer"
           ></Textarea>
-          <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-1 text-lg mt-2"
             data-test="numericalCorrectAnswer"
           >
@@ -204,9 +203,8 @@
               </table>
             </li>
           </ul>
-          <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixMatchCorrectAnswer"
           >
@@ -298,7 +296,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixRatingCorrectAnswer"
           >
@@ -383,7 +381,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixNumericalCorrectAnswer"
           >
@@ -563,9 +561,8 @@
               {{ charactersLeft }}
             </p>
           </div>
-          <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-1 text-lg mt-2"
             data-test="subjectiveCorrectAnswer"
           >
@@ -593,7 +590,7 @@
           ></Textarea>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-1 text-lg mt-2"
             data-test="numericalCorrectAnswer"
           >
@@ -683,7 +680,7 @@
           </ul>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixMatchCorrectAnswer"
           >
@@ -742,7 +739,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixRatingCorrectAnswer"
           >
@@ -795,7 +792,7 @@
           </div>
           <!-- answer display -->
           <div
-            v-if="hasQuizEnded && !isFormQuiz"
+            v-if="hasQuizEnded && !isFormQuiz && correctAnswer != null"
             class="px-2 text-lg mt-2"
             data-test="matrixNumericalCorrectAnswer"
           >
@@ -1015,6 +1012,10 @@ export default defineComponent({
         typeof props.correctAnswer == "number" || // check for typescript
         typeof state.draftAnswer == "number" // check for typescript
       ) {
+        return;
+      }
+      // correctAnswer is null/undefined during active attempts
+      if (!Array.isArray(props.correctAnswer)) {
         return;
       }
       if (
@@ -1547,36 +1548,41 @@ export default defineComponent({
       "bp-420:h-16 sm:h-20 md:h-22 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
     ]);
 
-    const numericalAnswerBoxStyling = computed(() => [
-      {
-        "text-green-500 border-green-500":
-          ((state.draftAnswer == props.correctAnswer &&
-            isQuestionTypeNumericalInteger.value) ||
-            (typeof state.draftAnswer == "number" &&
-              typeof props.correctAnswer == "number" &&
-              Math.abs(state.draftAnswer - props.correctAnswer) < 0.05 &&
-              isQuestionTypeNumericalFloat.value)) &&
-          isAnswerSubmitted.value &&
-          props.isGradedQuestion &&
-          (!isQuizAssessment.value ||
-            (isQuizAssessment.value && props.hasQuizEnded)),
-        "text-red-500 border-red-400":
-          ((state.draftAnswer != props.correctAnswer &&
-            isQuestionTypeNumericalInteger.value) ||
-            (typeof state.draftAnswer == "number" &&
-              typeof props.correctAnswer == "number" &&
-              Math.abs(state.draftAnswer - props.correctAnswer) >= 0.05 &&
-              isQuestionTypeNumericalFloat.value)) &&
-          isAnswerSubmitted.value &&
-          props.isGradedQuestion &&
-          (!isQuizAssessment.value ||
-            (isQuizAssessment.value && props.hasQuizEnded)),
-        "bg-gray-100":
-          (isAnswerSubmitted.value && !props.isGradedQuestion) ||
-          (isQuizAssessment.value && !props.hasQuizEnded),
-      },
-      "h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
-    ]);
+    const numericalAnswerBoxStyling = computed(() => {
+      const hasAnswer = props.correctAnswer !== undefined && props.correctAnswer !== null;
+      return [
+        {
+          "text-green-500 border-green-500":
+            hasAnswer &&
+            ((state.draftAnswer == props.correctAnswer &&
+              isQuestionTypeNumericalInteger.value) ||
+              (typeof state.draftAnswer == "number" &&
+                typeof props.correctAnswer == "number" &&
+                Math.abs(state.draftAnswer - props.correctAnswer) < 0.05 &&
+                isQuestionTypeNumericalFloat.value)) &&
+            isAnswerSubmitted.value &&
+            props.isGradedQuestion &&
+            (!isQuizAssessment.value ||
+              (isQuizAssessment.value && props.hasQuizEnded)),
+          "text-red-500 border-red-400":
+            hasAnswer &&
+            ((state.draftAnswer != props.correctAnswer &&
+              isQuestionTypeNumericalInteger.value) ||
+              (typeof state.draftAnswer == "number" &&
+                typeof props.correctAnswer == "number" &&
+                Math.abs(state.draftAnswer - props.correctAnswer) >= 0.05 &&
+                isQuestionTypeNumericalFloat.value)) &&
+            isAnswerSubmitted.value &&
+            props.isGradedQuestion &&
+            (!isQuizAssessment.value ||
+              (isQuizAssessment.value && props.hasQuizEnded)),
+          "bg-gray-100":
+            (isAnswerSubmitted.value && !props.isGradedQuestion) ||
+            (isQuizAssessment.value && !props.hasQuizEnded),
+        },
+        "h-12 px-4 placeholder-gray-400 focus:border-gray-200 focus:ring-primary disabled:cursor-not-allowed",
+      ];
+    });
 
     /**
      * Determines whether options should be displayed horizontally or vertically

--- a/src/services/Functional/Utilities.ts
+++ b/src/services/Functional/Utilities.ts
@@ -88,6 +88,18 @@ export function isQuestionAnswerCorrect(
     answered: false,
   } as answerEvaluation;
 
+  // correct_answer is omitted by backend during active attempts;
+  // can't evaluate correctness without it
+  if (
+    questionDetail.correct_answer === undefined ||
+    questionDetail.correct_answer === null
+  ) {
+    if (userAnswer != null) {
+      answerEvaluation.answered = true;
+    }
+    return answerEvaluation;
+  }
+
   if (questionDetail.graded) {
     answerEvaluation.valid = true;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,11 +179,16 @@ interface Option {
   image: Image | null;
 }
 
+/**
+ * `correct_answer` and `solution` are optional — the backend omits them
+ * during active attempts to prevent answer leakage. They're only present
+ * in review mode or after homework reveal.
+ */
 export interface Question {
   type: questionType;
   text: string;
   options: Option[] | null;
-  correct_answer: CorrectAnswerType;
+  correct_answer?: CorrectAnswerType;
   image: Image | null;
   max_char_limit: number | null;
   matrix_size: number[] | null;
@@ -191,7 +196,7 @@ export interface Question {
   graded: boolean;
   instructions: string | null;
   marking_scheme: MarkingScheme | null;
-  solution: string[] | null;
+  solution?: string[] | null;
   _id: string;
   metadata: QuestionMetadata | null;
   question_set_id: string;

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -1182,18 +1182,19 @@ export default defineComponent({
           let dynamicIndex = qindex;
           if (!isOmrMode.value) dynamicIndex = state.questionOrder[qindex];
           if (state.hasQuizEnded) {
+            // returns { valid: false } when correct_answer isn't available
             const questionAnswerEvaluation = isQuestionAnswerCorrect(
               state.questions[dynamicIndex],
               state.responses[dynamicIndex].answer,
               state.questions[dynamicIndex].marking_scheme?.partial != null // doesPartialMarkingExist
             )
-            if (!questionAnswerEvaluation.valid && state.questions[dynamicIndex].graded) continue
 
             if (!state.questions[dynamicIndex].graded) {
               qstate = "neutral"
             } else if (
+              !questionAnswerEvaluation.valid ||
               !questionAnswerEvaluation.answered ||
-          questionAnswerEvaluation.isCorrect == null
+              questionAnswerEvaluation.isCorrect == null
             ) {
               qstate = "neutral"
             } else {


### PR DESCRIPTION
ref #201

The quiz frontend currently assumes `correct_answer` will always be on the question object. If the backend ever stops sending it (which we need for preventing answer leakage during active attempts), a bunch of things break — palette colors, numerical input styling, and the "Correct Answer" text renders as null.

This makes the frontend okay with `correct_answer` being absent:

- Made `correct_answer` and `solution` optional in the Question type since they won't always be there
- `isQuestionAnswerCorrect` now bails early when there's no answer to compare against instead of blowing up
- The palette in Player.vue just shows neutral dots when it can't determine correctness
- Body.vue and SinglePageItem.vue skip the green/red styling on numerical inputs when we don't have the answer yet
- All the "Correct Answer: ..." labels are hidden when correctAnswer is null (was showing "Correct Answer: null" before lol)

Homework reveal still works fine — after you submit, the reveal endpoint populates the answer and everything lights up as expected. Same for review mode after quiz ends.

Backend changes to actually stop sending answers during active attempts will be a separate PR.
