### PR TITLE
Add required question support for forms

### DIFF
--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -22,8 +22,8 @@
       <!-- question text -->
       <div class="mx-6 md:mx-10" v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
         <div :class="questionTextClass" data-test="text">
-          <span v-if="isRequiredQuestion" class="text-red-600" aria-label="Required question">*</span>
           <span v-html="text"></span>
+          <span v-if="isRequiredQuestion" class="ml-1 text-red-600" aria-label="Required question">*</span>
         </div>
       </div>
       <div :class="orientationClass">

--- a/src/components/Questions/Body.vue
+++ b/src/components/Questions/Body.vue
@@ -21,7 +21,10 @@
       </div>
       <!-- question text -->
       <div class="mx-6 md:mx-10" v-bind="isQuizAssessment && !hasQuizEnded ? { inert: true } : {}">
-        <p :class="questionTextClass" data-test="text" v-html="text"></p>
+        <div :class="questionTextClass" data-test="text">
+          <span v-if="isRequiredQuestion" class="text-red-600" aria-label="Required question">*</span>
+          <span v-html="text"></span>
+        </div>
       </div>
       <div :class="orientationClass">
         <!-- loading spinner when question image is loading -->
@@ -741,6 +744,10 @@ export default defineComponent({
     testFormat: {
       type: [null, String] as PropType<testFormat>,
       default: null,
+    },
+    isRequiredQuestion: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props, context) {

--- a/src/components/Questions/QuestionModal.vue
+++ b/src/components/Questions/QuestionModal.vue
@@ -65,6 +65,7 @@
         :quizTimeLimit="quizTimeLimit"
         :numQuestions = "numQuestions"
         :questionOrder="questionOrder"
+        :isRequiredQuestion="areAllQuestionsRequired"
         @option-selected="questionOptionSelected"
         @subjective-answer-entered="subjectiveAnswerUpdated"
         @numerical-answer-entered="numericalAnswerUpdated"
@@ -248,6 +249,10 @@ export default defineComponent({
     displaySolution: {
       type: Boolean,
       default: true
+    },
+    areAllQuestionsRequired: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props, context) {

--- a/src/components/SinglePage/SinglePageItem.vue
+++ b/src/components/SinglePage/SinglePageItem.vue
@@ -8,8 +8,8 @@
           {{ questionHeaderText }}
         </p>
         <div v-if="questionText" class="text-base md:text-lg mb-2 leading-relaxed whitespace-pre-wrap" v-lazy-images>
-          <span v-if="isRequiredQuestion" class="text-red-600 font-bold" aria-label="Required question">*</span>
           <span v-html="questionText"></span>
+          <span v-if="isRequiredQuestion" class="ml-1 text-red-600 font-bold" aria-label="Required question">*</span>
         </div>
       </div>
       <!-- Question image if present -->

--- a/src/components/SinglePage/SinglePageItem.vue
+++ b/src/components/SinglePage/SinglePageItem.vue
@@ -7,7 +7,10 @@
         <p class="text-lg md:text-xl font-bold mb-2" data-test="question-header-text">
           {{ questionHeaderText }}
         </p>
-        <p v-if="questionText" class="text-base md:text-lg mb-2 leading-relaxed whitespace-pre-wrap" v-html="questionText" v-lazy-images></p>
+        <div v-if="questionText" class="text-base md:text-lg mb-2 leading-relaxed whitespace-pre-wrap" v-lazy-images>
+          <span v-if="isRequiredQuestion" class="text-red-600 font-bold" aria-label="Required question">*</span>
+          <span v-html="questionText"></span>
+        </div>
       </div>
       <!-- Question image if present -->
       <div v-if="questionImage && questionImage.url" class="mb-4 flex justify-center">
@@ -1024,6 +1027,10 @@ export default defineComponent({
     difficultyBadgeClass: {
       type: String,
       default: null,
+    },
+    isRequiredQuestion: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props, context) {

--- a/src/components/SinglePage/SinglePageModal.vue
+++ b/src/components/SinglePage/SinglePageModal.vue
@@ -53,6 +53,7 @@
                 :difficulty="$props.questions[questionState.index].metadata?.difficulty_label || $props.questions[questionState.index].metadata?.difficulty"
                 :difficultyBadgeClass="$props.questions[questionState.index].metadata?.difficulty_badge_class"
                 :displaySolution="displaySolution"
+                :isRequiredQuestion="areAllQuestionsRequired"
                 @option-selected="questionOptionSelected"
                 @subjective-answer-entered="subjectiveAnswerUpdated"
                 @numerical-answer-entered="numericalAnswerUpdated"
@@ -225,6 +226,10 @@ export default defineComponent({
     displaySolution: {
       type: Boolean,
       default: true,
+    },
+    areAllQuestionsRequired: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props, context) {

--- a/src/services/API/Session.ts
+++ b/src/services/API/Session.ts
@@ -33,6 +33,8 @@ export default {
     } catch (error: any) {
       if (error.code == 'ECONNABORTED') {
         return { status: 500 }; // request timeout
+      } else if (error.response?.status != null) {
+        return { status: error.response.status, data: error.response.data };
       } else {
         return { status: 400 }; // bad request
       }

--- a/src/services/Functional/Utilities.ts
+++ b/src/services/Functional/Utilities.ts
@@ -68,6 +68,43 @@ export function resetConfetti() {
   }
 }
 
+export function isQuestionResponseComplete(
+  questionDetail: Question,
+  userAnswer: submittedAnswer
+): boolean {
+  if (userAnswer == null) return false;
+
+  if (questionDetail.type == "subjective") {
+    return typeof userAnswer == "string" && userAnswer.trim() != "";
+  }
+
+  if (
+    questionDetail.type == "numerical-integer" ||
+    questionDetail.type == "numerical-float"
+  ) {
+    return typeof userAnswer == "number";
+  }
+
+  if (
+    questionDetail.type == "matrix-rating" ||
+    questionDetail.type == "matrix-numerical" ||
+    questionDetail.type == "matrix-subjective"
+  ) {
+    if (typeof userAnswer != "object" || Array.isArray(userAnswer)) return false;
+    const matrixRows = questionDetail.matrix_rows || [];
+    if (matrixRows.length == 0) return false;
+    if (questionDetail.type == "matrix-subjective") {
+      const filledRows = Object.entries(userAnswer).filter(([, val]) => {
+        return typeof val == "string" && val.trim() != "";
+      });
+      return filledRows.length == matrixRows.length;
+    }
+    return Object.keys(userAnswer).length == matrixRows.length;
+  }
+
+  return Array.isArray(userAnswer) && userAnswer.length > 0;
+}
+
 /**
  * Given a question and its corresponding answer, this method checks if the answer is correct.
  * If the question is ungraded, the method returns that the evaluation is invalid.

--- a/src/services/Functional/Utilities.ts
+++ b/src/services/Functional/Utilities.ts
@@ -93,13 +93,14 @@ export function isQuestionResponseComplete(
     if (typeof userAnswer != "object" || Array.isArray(userAnswer)) return false;
     const matrixRows = questionDetail.matrix_rows || [];
     if (matrixRows.length == 0) return false;
-    if (questionDetail.type == "matrix-subjective") {
-      const filledRows = Object.entries(userAnswer).filter(([, val]) => {
-        return typeof val == "string" && val.trim() != "";
-      });
-      return filledRows.length == matrixRows.length;
+    const rowValues = matrixRows.map((row) => userAnswer[row]);
+    if (
+      questionDetail.type == "matrix-subjective" ||
+      questionDetail.type == "matrix-numerical"
+    ) {
+      return rowValues.every((val) => typeof val == "string" && val.trim() != "");
     }
-    return Object.keys(userAnswer).length == matrixRows.length;
+    return rowValues.every((val) => typeof val == "number");
   }
 
   return Array.isArray(userAnswer) && userAnswer.length > 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,6 +285,10 @@ export interface UpdateSessionAPIPayload {
 export interface UpdateSessionAPIResponse {
   time_remaining?: number; // how much time is remaining for quiz to complete
   metrics?: SessionMetricsPayload | null;
+  detail?: {
+    message?: string;
+    missing_positions?: number[];
+  };
 }
 
 export interface SessionAnswerAPIResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,7 @@ export interface QuizAPIResponse {
   review_immediate?: boolean;
   show_scores?: boolean;
   display_solution?: boolean;
+  require_all_questions?: boolean;
   question_sets: QuestionSet[];
 }
 

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -66,6 +66,7 @@
         :maxMarks="maxMarks"
         :showFullText="showFullText"
         :displaySolution="displaySolution"
+        :areAllQuestionsRequired="areAllQuestionsRequired"
         v-model:currentQuestionIndex="currentQuestionIndex"
         v-model:responses="responses"
         v-model:previousOmrResponses="previousOmrResponses"
@@ -99,6 +100,7 @@
         :testFormat="metadata.test_format || ''"
         :maxMarks="maxMarks"
         :questionOrder="questionOrder"
+        :areAllQuestionsRequired="areAllQuestionsRequired"
         v-model:shuffledQuestionIndex="shuffledQuestionIndex"
         v-model:currentQuestionIndex="currentQuestionIndex"
         v-model:responses="responses"
@@ -160,7 +162,7 @@ import QuestionModal from "../components/Questions/QuestionModal.vue";
 import SinglePageModal from "../components/SinglePage/SinglePageModal.vue"
 import Splash from "../components/Splash.vue";
 import Scorecard from "../components/Scorecard.vue";
-import { resetConfetti, isQuestionAnswerCorrect, isQuestionFetched, createQuestionBuckets } from "../services/Functional/Utilities";
+import { resetConfetti, isQuestionAnswerCorrect, isQuestionFetched, createQuestionBuckets, isQuestionResponseComplete } from "../services/Functional/Utilities";
 import QuizAPIService from "../services/API/Quiz";
 import FormAPIService from "../services/API/Form";
 import SessionAPIService from "../services/API/Session";
@@ -281,6 +283,7 @@ export default defineComponent({
       quizLoadedWithAnswers: false, // whether last quiz fetch included correct_answer/solution
       displaySolution: true as boolean, // whether solutions to each question should be displayed
       showScores: true as boolean, // whether we should show scores after quiz has ended
+      requireAllQuestions: false as boolean,
       sessionEndTimeText: "", // session end time in text if available
       sessionId: "", // id of the session created for a user-quiz combination
       isSessionAnswerRequestProcessing: false, // whether session answer api request is processing
@@ -306,6 +309,8 @@ export default defineComponent({
     });
 
     const isFormQuiz = computed(() => state.metadata.quiz_type == "form");
+
+    const areAllQuestionsRequired = computed(() => isFormQuiz.value && state.requireAllQuestions);
 
     const showFullText = computed(() => !isOmrMode.value && props.singlePageMode);
 
@@ -692,6 +697,7 @@ export default defineComponent({
       state.title = quizDetails.title;
       state.displaySolution = quizDetails?.display_solution ?? true;
       state.showScores = quizDetails?.show_scores ?? true;
+      state.requireAllQuestions = quizDetails?.require_all_questions ?? false;
 
       if (enableBucketing) {
         createQuestionBuckets(totalQuestionsInEachSet);
@@ -942,6 +948,22 @@ export default defineComponent({
       if (state.hasQuizEnded) {
         state.currentQuestionIndex = numQuestions.value;
         state.isScorecardShown = true;
+        return;
+      }
+
+      const incompleteQuestionIndex = state.questions.findIndex((question, idx) => {
+        return !isQuestionResponseComplete(question, state.responses[idx]?.answer ?? null);
+      });
+      if (areAllQuestionsRequired.value && incompleteQuestionIndex != -1) {
+        state.toast.warning(
+          `Please answer all required questions before submitting. Question ${incompleteQuestionIndex + 1} is incomplete.`,
+          {
+            position: POSITION.TOP_CENTER,
+            timeout: 7000,
+            draggablePercent: 0.4
+          }
+        );
+        state.currentQuestionIndex = incompleteQuestionIndex;
         return;
       }
 
@@ -1306,6 +1328,7 @@ export default defineComponent({
       isSplashShown,
       isQuizAssessment,
       isFormQuiz,
+      areAllQuestionsRequired,
       scorecardMetrics,
       scorecardProgress,
       numQuestionsAnswered,

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -326,6 +326,29 @@ export default defineComponent({
       return isOmrMode.value ? "omr-assessment" : "assessment";
     });
 
+    function displayIndexForQuestionPosition(positionIndex: number) {
+      if (isOmrMode.value) return positionIndex;
+      const displayIndex = state.questionOrder.indexOf(positionIndex);
+      return displayIndex == -1 ? positionIndex : displayIndex;
+    }
+
+    function navigateToIncompleteQuestion(positionIndex: number) {
+      const displayIndex = displayIndexForQuestionPosition(positionIndex);
+      state.currentQuestionIndex = displayIndex;
+    }
+
+    function showIncompleteRequiredQuestionWarning(positionIndex: number) {
+      state.toast.warning(
+        `Please answer all required questions before submitting. Question ${displayIndexForQuestionPosition(positionIndex) + 1} is incomplete.`,
+        {
+          position: POSITION.TOP_CENTER,
+          timeout: 7000,
+          draggablePercent: 0.4
+        }
+      );
+      navigateToIncompleteQuestion(positionIndex);
+    }
+
     // const shouldShowOmrToggle = computed(() => state.metadata.quiz_type == "assessment")
     const shouldShowOmrToggle = computed(() => false)
 
@@ -955,15 +978,7 @@ export default defineComponent({
         return !isQuestionResponseComplete(question, state.responses[idx]?.answer ?? null);
       });
       if (areAllQuestionsRequired.value && incompleteQuestionIndex != -1) {
-        state.toast.warning(
-          `Please answer all required questions before submitting. Question ${incompleteQuestionIndex + 1} is incomplete.`,
-          {
-            position: POSITION.TOP_CENTER,
-            timeout: 7000,
-            draggablePercent: 0.4
-          }
-        );
-        state.currentQuestionIndex = incompleteQuestionIndex;
+        showIncompleteRequiredQuestionWarning(incompleteQuestionIndex);
         return;
       }
 
@@ -1007,6 +1022,13 @@ export default defineComponent({
       };
       const endSessionResponse = await SessionAPIService.updateSession(state.sessionId, payload);
       if (endSessionResponse.status != 200) {
+        const missingPositions = endSessionResponse.data?.detail?.missing_positions;
+        if (areAllQuestionsRequired.value && Array.isArray(missingPositions) && missingPositions.length > 0) {
+          showIncompleteRequiredQuestionWarning(missingPositions[0]);
+          state.isComputingScore = false;
+          state.isSessionAnswerRequestProcessing = false;
+          return;
+        }
         state.toast.error(
           'Unable to complete test submission due to poor connection. Please retry "End Test" to complete.',
           {


### PR DESCRIPTION
## Summary
- Reads `require_all_questions` from the quiz payload for form quizzes.
- Shows a red required marker next to form question text when all questions are required.
- Blocks final form submission when any required question is incomplete and navigates to the first incomplete question.

## Related
- Backend PR: https://github.com/avantifellows/quiz-backend/pull/157
- Creator/sessionCreator/quiz ETL changes are already on `quiz-creator` and `etl-data-flow` main.

