### PR TITLE
fix: resync local timer from server on each poll to prevent drift after disconnects

### DIFF
--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -579,8 +579,12 @@ export default defineComponent({
           state.sessionId,
           payload
         );
-        if (response.status == 200 && response.data?.time_remaining == 0) {
-          endTest()
+        if (response.status == 200 && response.data?.time_remaining != null) {
+          if (response.data.time_remaining == 0) {
+            endTest()
+          } else {
+            state.timeRemaining = response.data.time_remaining
+          }
         }
 
         // updates time spent on question for homeworks and assessments


### PR DESCRIPTION
## Summary
After power cuts or network disconnects, the local browser timer drifts ahead of the server clock, causing students' tests to end early. The server clock is authoritative and pauses during outages — this fix resyncs the local clock from it.

## Related Issue
Fixes #218

## What changed
In \	imerUpdates()\ (Player.vue): on every successful 20s poll, if the server returns \	ime_remaining\, update \state.timeRemaining\ to match. Previously the server value was only checked for 0 (to end the test); non-zero values were ignored.

## Why this approach
Minimal change — the server is already authoritative and already pauses during disconnects. The Header component already watches \	imeRemaining\ prop and updates its local countdown, so the resync flows through automatically.

## Testing done
- Lint passes
- Unit tests pass (10/10 in Header.spec.ts)
- Verified \state.timeRemaining\ is passed as prop to Header which watches it

## Checklist
- [x] Tests added/updated
- [x] Lint/format passes
- [x] Linked issue referenced
- [x] Commits signed off
- [x] No unrelated changes bundled in